### PR TITLE
refactor: rely on encodeURIComponent

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
 export const clamp = (n:number,min:number,max:number)=>Math.max(min,Math.min(max,n));
 export const generateIdentifier=():string=>{const b=(l:number)=>Array.from({length:l},()=>"ABCDEFGHJKLMNPQRSTUVWXYZ23456789"[Math.floor(Math.random()*34)]).join('');return `${b(3)}-${b(6)}`;}
 export const sanitizeMessage=(m:string)=>m.trim().slice(0,500).replace(/[\u0000-\u001F\u007F]/g,'');
-export const buildMonoUrl=(jarId:string,amount:number,msg:string)=>{let t=encodeURIComponent(msg).replace(/%20/g,'%20').replace(/%28/g,'(').replace(/%29/g,')');return `https://send.monobank.ua/jar/${jarId}?a=${Math.round(amount)}&t=${t}`;}
+export const buildMonoUrl=(jarId:string,amount:number,msg:string)=>{let t=encodeURIComponent(msg).replace(/%28/g,'(').replace(/%29/g,')');return `https://send.monobank.ua/jar/${jarId}?a=${Math.round(amount)}&t=${t}`;}
 export type DonationIntent={identifier:string;nickname:string;message:string;amount:number;createdAt:string};
 export type DonationEvent={identifier:string;nickname:string;message:string;amount:number;monoComment:string;createdAt:string};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "test": "node --test --import tsx test/store.test.ts"
+    "test": "node --test --import tsx test/*.test.ts"
   },
   "dependencies": {
     "clsx": "2.1.1",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,8 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { buildMonoUrl } from '../lib/utils.ts'
+
+test('buildMonoUrl encodes message', () => {
+  const url = buildMonoUrl('JAR', 50, 'Hello world (foo) & bar')
+  assert.strictEqual(url, 'https://send.monobank.ua/jar/JAR?a=50&t=Hello%20world%20(foo)%20%26%20bar')
+})


### PR DESCRIPTION
## Summary
- rely on encodeURIComponent for message encoding in buildMonoUrl
- run all tests and add a URL builder test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cd1a7c948326a0e7bf63ce43aae8