### PR TITLE
refactor: use named export for AmountPresets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useMemo } from 'react'; import AmountPresets from '@/components/AmountPresets';
+import { useState, useMemo } from 'react'; import { AmountPresets } from '@/components/AmountPresets';
 const MIN=5, MAX=5_000_000;
 export default function HomePage(){
   const [nickname,setNickname]=useState(''); const [amount,setAmount]=useState<number>(50); const [message,setMessage]=useState(''); const [submitting,setSubmitting]=useState(false); const [testing,setTesting]=useState(false); const [error,setError]=useState(''); const [toast,setToast]=useState('');

--- a/components/AmountPresets.tsx
+++ b/components/AmountPresets.tsx
@@ -1,2 +1,2 @@
 'use client'; import { clsx } from 'clsx'; type Props={value:number;onChange:(n:number)=>void}; const presets=[20,50,100,200];
-export default function AmountPresets({value,onChange}:Props){return(<div className="flex flex-wrap gap-3">{presets.map(p=>(<button key={p} type="button" aria-label={`Обрати ${p} гривень`} className={clsx('pill', value===p && 'ring-2 ring-purple-400')} onClick={()=>onChange(p)}>{p}</button>))}</div>);}
+export function AmountPresets({value,onChange}:Props){return(<div className="flex flex-wrap gap-3">{presets.map(p=>(<button key={p} type="button" aria-label={`Обрати ${p} гривень`} className={clsx('pill', value===p && 'ring-2 ring-purple-400')} onClick={()=>onChange(p)}>{p}</button>))}</div>);}


### PR DESCRIPTION
## Summary
- refactor AmountPresets to use a named export
- update HomePage to use the named import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ce5295188326b92abf2f956f0a75