### PR TITLE
refactor: tidy stream route

### DIFF
--- a/app/api/stream/route.ts
+++ b/app/api/stream/route.ts
@@ -1,3 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server'; import { addClient } from '@/lib/sse';
-export const runtime='nodejs';
-export async function GET(){ const {stream}=addClient(); return new NextResponse(stream,{headers:{'Content-Type':'text/event-stream; charset=utf-8','Cache-Control':'no-cache, no-transform','Connection':'keep-alive','Access-Control-Allow-Origin':'*','X-Accel-Buffering':'no'}}) }
+import { NextResponse } from 'next/server';
+import { addClient } from '@/lib/sse';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const { stream } = addClient();
+
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204 });
+}
+


### PR DESCRIPTION
## Summary
- remove unused `NextRequest`
- drop wildcard CORS header and format SSE handler
- handle OPTIONS requests for the stream endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cf13418c83269aba512864bc9be5