### PR TITLE
Refine monobank webhook payload handling

### DIFF
--- a/app/api/monobank/webhook/route.ts
+++ b/app/api/monobank/webhook/route.ts
@@ -1,15 +1,68 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { appendDonationEvent, findIntentByIdentifier } from '@/lib/store';
 import { broadcastDonation } from '@/lib/sse';
-export const runtime='nodejs';
-export async function POST(req: NextRequest){
-  const admin=process.env.ADMIN_TOKEN; const hdr=req.headers.get('x-admin-token');
-  if(admin && hdr!==admin) return NextResponse.json({ok:false,error:'Unauthorized'},{status:401});
-  let payload:any={}; try{payload=await req.json()}catch{return NextResponse.json({ok:false,error:'Invalid JSON'},{status:400})}
-  const item=payload?.data?.statementItem||payload?.statementItem||payload;
-  const comment=String(item?.comment||item?.description||''); const minor=Number(item?.amount||0); const amount=Math.round(minor)/100;
-  const m=comment.match(/\(([A-Z0-9-]{6,})\)/i); if(!m) return NextResponse.json({ok:true,ignored:true,reason:'No identifier'});
-  const id=m[1]; const intent=await findIntentByIdentifier(id); if(!intent) return NextResponse.json({ok:true,ignored:true,reason:'Identifier not found'});
-  const ev={identifier:id,nickname:intent.nickname,message:intent.message,amount,monoComment:comment,createdAt:new Date().toISOString()};
-  await appendDonationEvent(ev); broadcastDonation(ev); return NextResponse.json({ok:true});
+
+export const runtime = 'nodejs';
+
+interface StatementItem {
+  comment?: string;
+  description?: string;
+  amount?: number;
+}
+
+interface MonobankWebhookBody {
+  data?: { statementItem?: StatementItem };
+  statementItem?: StatementItem;
+  comment?: string;
+  description?: string;
+  amount?: number;
+}
+
+export async function POST(req: NextRequest) {
+  const admin = process.env.ADMIN_TOKEN;
+  const hdr = req.headers.get('x-admin-token');
+  if (admin && hdr !== admin)
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (!json || typeof json !== 'object')
+    return NextResponse.json({ ok: false, error: 'Invalid body' }, { status: 400 });
+
+  const payload = json as MonobankWebhookBody;
+  const item =
+    payload?.data?.statementItem ||
+    payload?.statementItem ||
+    payload;
+
+  const comment = String(item?.comment || item?.description || '');
+  const minor = Number(item?.amount || 0);
+  const amount = Math.round(minor) / 100;
+
+  const m = comment.match(/\(([A-Z0-9-]{6,})\)/i);
+  if (!m)
+    return NextResponse.json({ ok: true, ignored: true, reason: 'No identifier' });
+
+  const id = m[1];
+  const intent = await findIntentByIdentifier(id);
+  if (!intent)
+    return NextResponse.json({ ok: true, ignored: true, reason: 'Identifier not found' });
+
+  const ev = {
+    identifier: id,
+    nickname: intent.nickname,
+    message: intent.message,
+    amount,
+    monoComment: comment,
+    createdAt: new Date().toISOString(),
+  };
+
+  await appendDonationEvent(ev);
+  broadcastDonation(ev);
+  return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- define typed interface for monobank webhook payload
- validate `req.json()` result and reject invalid bodies with 400
- remove `any` usage and expand webhook route into readable multi-line format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d02a37c08326bec692bf9c025d1b