### PR TITLE
Disable caching for OBS widget

### DIFF
--- a/app/obs/layout.tsx
+++ b/app/obs/layout.tsx
@@ -1,1 +1,17 @@
-export default function OBSLayout({children}:{children:React.ReactNode}){return(<html lang='uk'><body style={{background:'transparent'}}>{children}</body></html>)}
+import type { ReactNode } from "react";
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export default function OBSLayout({ children }: LayoutProps) {
+  return (
+    <html lang="uk">
+      <head>
+        <meta httpEquiv="Cache-Control" content="no-store" />
+      </head>
+      <body style={{ background: "transparent" }}>{children}</body>
+    </html>
+  );
+}
+

--- a/app/obs/page.tsx
+++ b/app/obs/page.tsx
@@ -13,6 +13,8 @@ interface EventPayload {
 type ConnectionState = "connecting" | "connected" | "error";
 
 export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
 
 export default function OBSWidgetPage() {
   const [visible, setVisible] = useState(false);
@@ -54,7 +56,7 @@ export default function OBSWidgetPage() {
     let es: EventSource;
     function connect() {
       setConnectionState("connecting");
-      es = new EventSource("/api/stream");
+      es = new EventSource("/api/stream?ts=" + Date.now());
       es.addEventListener("open", () => setConnectionState("connected"));
       es.addEventListener("error", (err) => {
         console.error("EventSource error", err);


### PR DESCRIPTION
## Summary
- disable Next.js caching for OBS widget by exporting `revalidate` and `fetchCache`
- append timestamp to SSE connection to bypass intermediates
- add `Cache-Control: no-store` meta tag for OBS layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898db6f0bc88326b25f83896ea4e811