### PR TITLE
Expand OBS alert to 80% of canvas

### DIFF
--- a/app/obs/obs-widget-client.tsx
+++ b/app/obs/obs-widget-client.tsx
@@ -78,8 +78,8 @@ export function ObsWidgetClient() {
       style={{ background: "transparent" }}
     >
       {visible && data && (
-        <div className="animate-pop scale-[0.8]">
-          <div className="rounded-3xl bg-white/80 text-neutral-900 shadow-2xl backdrop-blur-xl px-6 py-4 min-w-[360px] ring-1 ring-black/5"
+        <div className="animate-pop w-[80vw] h-[80vh] flex items-center justify-center">
+          <div className="rounded-3xl bg-white/80 text-neutral-900 shadow-2xl backdrop-blur-xl px-6 py-4 w-full h-full ring-1 ring-black/5"
             style={{ WebkitBackdropFilter: "blur(16px)" }}
           >
             <div className="text-sm opacity-70 mb-1">Дякуємо за підтримку!</div>


### PR DESCRIPTION
## Summary
- Expand inner OBS alert wrapper to 80% viewport width/height and center content
- Allow alert box to scale with wrapper by removing fixed min width and using full size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e79da1148326b767edc79f5eaadd