### PR TITLE
feat: add monobank status endpoint and admin page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from 'react';
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import { StatusClient, StatusData } from './status-client';
+
+export default async function AdminPage() {
+  const token = process.env.ADMIN_TOKEN;
+  if (token) {
+    const auth = headers().get('authorization');
+    if (auth !== `Bearer ${token}`) notFound();
+  }
+
+  const h = headers();
+  const proto = h.get('x-forwarded-proto') ?? 'http';
+  const host = h.get('host') ?? 'localhost';
+  const res = await fetch(`${proto}://${host}/api/monobank/status`, { cache: 'no-store' });
+  const status: StatusData = await res.json();
+
+  return (
+    <main className="min-h-screen relative overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-40 -left-40 h-[36rem] w-[36rem] rounded-full bg-fuchsia-600/20 blur-3xl" />
+        <div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl" />
+      </div>
+      <div className="relative mx-auto max-w-2xl px-6 py-14">
+        <header className="mb-8 text-center">
+          <h1 className="text-4xl md:text-5xl font-extrabold title-gradient drop-shadow-sm">Admin</h1>
+          <div className="mt-3 badge">Monobank status</div>
+        </header>
+        <div className="card p-6 md:p-8">
+          <Suspense fallback={<p className="text-center text-neutral-400">Loading…</p>}>
+            <StatusClient initial={status} />
+          </Suspense>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/status-client.tsx
+++ b/app/admin/status-client.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { DonationEvent } from '@/lib/utils';
+
+export interface StatusData {
+  isActive: boolean;
+  event: DonationEvent | null;
+}
+
+interface StatusClientProps {
+  initial: StatusData;
+}
+
+export function StatusClient({ initial }: StatusClientProps) {
+  const [data, setData] = useState<StatusData>(initial);
+  useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const res = await fetch('/api/monobank/status', { cache: 'no-store' });
+        const json: StatusData = await res.json();
+        setData(json);
+      } catch {}
+    }, 10_000);
+    return () => clearInterval(id);
+  }, []);
+  return <StatusDetails data={data} />;
+}
+
+function StatusDetails({ data }: { data: StatusData }) {
+  if (!data.event)
+    return <p className="text-center text-neutral-400">No events yet</p>;
+  const ev = data.event;
+  const time = new Date(ev.createdAt).toLocaleString();
+  return (
+    <div className="grid gap-2 text-center">
+      <p className="text-sm text-neutral-300">{time}</p>
+      <p className="font-mono">{ev.identifier}</p>
+      <p className="text-xl font-semibold">{ev.amount.toFixed(2)} ₴</p>
+    </div>
+  );
+}

--- a/app/api/monobank/status/route.ts
+++ b/app/api/monobank/status/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { listDonationEvents } from '@/lib/store';
+import type { DonationEvent } from '@/lib/utils';
+
+export const runtime = 'nodejs';
+
+interface StatusResponse {
+  isActive: boolean;
+  event: DonationEvent | null;
+}
+
+export async function GET() {
+  try {
+    const events = await listDonationEvents();
+    const event = events.at(-1) ?? null;
+    const body: StatusResponse = { isActive: Boolean(event), event };
+    return NextResponse.json(body);
+  } catch (err) {
+    console.error('Failed to read donation events', err);
+    const body: StatusResponse = { isActive: false, event: null };
+    return NextResponse.json(body, { status: 500 });
+  }
+}

--- a/test/monobank-status.test.ts
+++ b/test/monobank-status.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { GET } from '@/app/api/monobank/status/route.ts';
+import type { DonationEvent } from '@/lib/utils';
+
+const eventsPath = path.join(process.cwd(), 'data', 'donations.json');
+
+async function writeEvents(events: DonationEvent[]) {
+  await fs.mkdir(path.dirname(eventsPath), { recursive: true });
+  await fs.writeFile(eventsPath, JSON.stringify(events), 'utf8');
+}
+
+test('reports inactive when no events', async () => {
+  await writeEvents([]);
+  const res = await GET();
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.deepStrictEqual(body, { isActive: false, event: null });
+});
+
+test('returns latest event', async () => {
+  const events: DonationEvent[] = [
+    {
+      identifier: 'AAA-111',
+      nickname: 'x',
+      message: 'm',
+      amount: 1,
+      monoComment: '',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    },
+    {
+      identifier: 'BBB-222',
+      nickname: 'y',
+      message: 'n',
+      amount: 2,
+      monoComment: '',
+      createdAt: '2024-01-02T00:00:00.000Z',
+    },
+  ];
+  await writeEvents(events);
+  const res = await GET();
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.deepStrictEqual(body, { isActive: true, event: events[1] });
+});


### PR DESCRIPTION
## Summary
- expose `/api/monobank/status` for latest donation event and active flag
- add admin dashboard fetching status with auto-refresh
- cover status endpoint with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f5774e888326aa568aa01a2115e7