### PR TITLE
feat: auto-configure monobank webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Personal token for Monobank API to auto-configure webhook
+MONOBANK_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env*
+!.env.example
 node_modules/
 .next/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 - `/obs` без SSR-помилок (жодних звернень до `window` під час рендеру).
 - SSE з heartbeat кожні 15с, щоб не засинав конекшн.
 - Для реального вебхука потрібен публічний HTTPS. За бажанням встановіть `MONOBANK_WEBHOOK_SECRET` і перевіряйте підпис `X-Sign`.
+- Якщо встановлено `MONOBANK_TOKEN`, ендпоінт `/api/monobank/status` автоматично реєструє вебхук на `/api/monobank/webhook`.
 
 Запуск: `pnpm i && cp .env.example .env.local && pnpm dev`

--- a/app/api/monobank/status/route.ts
+++ b/app/api/monobank/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { listDonationEvents } from '@/lib/store';
+import { configureWebhook } from '@/lib/monobank-webhook';
 import type { DonationEvent } from '@/lib/utils';
 
 export const runtime = 'nodejs';
@@ -9,8 +10,16 @@ interface StatusResponse {
   event: DonationEvent | null;
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    try {
+      const requestURL = request.url;
+      await configureWebhook(
+        new URL('/api/monobank/webhook', requestURL).href,
+      );
+    } catch (err) {
+      console.error('Failed to configure Monobank webhook', err);
+    }
     const events = await listDonationEvents();
     const event = events.at(-1) ?? null;
     const body: StatusResponse = { isActive: Boolean(event), event };

--- a/lib/monobank-webhook.ts
+++ b/lib/monobank-webhook.ts
@@ -1,0 +1,13 @@
+export async function configureWebhook(webhookUrl: string): Promise<void> {
+  const token = process.env.MONOBANK_TOKEN;
+  if (!token) return;
+  const res = await fetch('https://api.monobank.ua/personal/webhook', {
+    method: 'POST',
+    headers: {
+      'X-Token': token,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ webHookUrl: webhookUrl }),
+  });
+  if (!res.ok) throw new Error(`Failed to configure Monobank webhook: ${res.status}`);
+}

--- a/test/monobank-status.test.ts
+++ b/test/monobank-status.test.ts
@@ -14,7 +14,7 @@ async function writeEvents(events: DonationEvent[]) {
 
 test('reports inactive when no events', async () => {
   await writeEvents([]);
-  const res = await GET();
+  const res = await GET(new Request('http://localhost'));
   assert.strictEqual(res.status, 200);
   const body = await res.json();
   assert.deepStrictEqual(body, { isActive: false, event: null });
@@ -40,7 +40,7 @@ test('returns latest event', async () => {
     },
   ];
   await writeEvents(events);
-  const res = await GET();
+  const res = await GET(new Request('http://localhost'));
   assert.strictEqual(res.status, 200);
   const body = await res.json();
   assert.deepStrictEqual(body, { isActive: true, event: events[1] });

--- a/test/monobank-webhook-config.test.ts
+++ b/test/monobank-webhook-config.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { configureWebhook } from '@/lib/monobank-webhook';
+
+test('sends POST to Monobank with token', async (t) => {
+  process.env.MONOBANK_TOKEN = 'token';
+  const fetchMock = t.mock.method(globalThis, 'fetch', async () =>
+    new Response('{}', { status: 200 }),
+  );
+  await configureWebhook('https://example.com/hook');
+  assert.strictEqual(fetchMock.mock.calls.length, 1);
+  const [url, options] = fetchMock.mock.calls[0].arguments;
+  assert.strictEqual(url, 'https://api.monobank.ua/personal/webhook');
+  assert.strictEqual(options?.method, 'POST');
+  assert.strictEqual(options?.headers?.['X-Token'], 'token');
+  assert.strictEqual(
+    options?.body,
+    JSON.stringify({ webHookUrl: 'https://example.com/hook' }),
+  );
+  delete process.env.MONOBANK_TOKEN;
+});
+
+test('throws on non-ok response', async (t) => {
+  process.env.MONOBANK_TOKEN = 'token';
+  t.mock.method(globalThis, 'fetch', async () =>
+    new Response('err', { status: 500 }),
+  );
+  await assert.rejects(
+    () => configureWebhook('https://example.com/hook'),
+    /Monobank webhook/,
+  );
+  delete process.env.MONOBANK_TOKEN;
+});


### PR DESCRIPTION
## Summary
- add MONOBANK_TOKEN env variable
- automatically register webhook when checking Monobank status
- test webhook configuration logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898fa2819588326af5f584be2c84df2