### PR TITLE
feat: add webhook GET handler

### DIFF
--- a/app/api/monobank/webhook/route.ts
+++ b/app/api/monobank/webhook/route.ts
@@ -5,6 +5,10 @@ import { broadcastDonation } from '@/lib/sse';
 
 export const runtime = 'nodejs';
 
+export function GET() {
+  return NextResponse.json({ ok: true });
+}
+
 interface StatementItem {
   comment?: string;
   description?: string;

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,7 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert'
 import { NextRequest } from 'next/server'
-import { POST } from '@/app/api/monobank/webhook/route.ts'
+import { GET, POST } from '@/app/api/monobank/webhook/route.ts'
+
+test('GET /api/monobank/webhook returns 200', async function () {
+  const res = await GET()
+  assert.strictEqual(res.status, 200)
+  const body = await res.json()
+  assert.deepStrictEqual(body, { ok: true })
+})
 
 // Ensure non-positive amounts are ignored
 test('ignores non-positive amount', async () => {


### PR DESCRIPTION
## Summary
- handle Monobank webhook GET request with ok:true response
- cover webhook GET handler with integration test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689900160b90832689fe55bd093e3f82