### PR TITLE
feat: add prisma storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
+# SQLite connection for Prisma
+DATABASE_URL="file:./dev.db"
+# Monobank jar identifier
+JAR_ID=
 # Personal token for Monobank API to auto-configure webhook
 MONOBANK_TOKEN=

--- a/app/admin/status-client.tsx
+++ b/app/admin/status-client.tsx
@@ -1,10 +1,10 @@
 'use client';
 import { useEffect, useState } from 'react';
-import type { DonationEvent } from '@/lib/utils';
+import type { DonationEvent } from '@prisma/client';
 
 export interface StatusData {
   isActive: boolean;
-  event: DonationEvent | null;
+  event: (DonationEvent & { createdAt: string }) | null;
 }
 
 interface StatusClientProps {

--- a/app/api/donations/create/route.ts
+++ b/app/api/donations/create/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { appendIntent } from '@/lib/store';
+import { appendIntent, getSetting } from '@/lib/store';
 import { buildMonoUrl, clamp, generateIdentifier, sanitizeMessage } from '@/lib/utils';
 export const runtime='nodejs';
 export async function GET(req: NextRequest){
@@ -7,8 +7,8 @@ export async function GET(req: NextRequest){
   const nickname=(sp.get('nickname')||'').trim().slice(0,64);
   const message=sanitizeMessage(sp.get('message')||'');
   const amountParam=Number(sp.get('amount')||'0');
-  const jarId=process.env.JAR_ID;
-  if(!jarId) return NextResponse.json({error:'Missing JAR_ID'}, {status:500});
+  const jarId=await getSetting('jarId')||process.env.JAR_ID||'';
+  if(!jarId) return NextResponse.json({error:'Missing jarId'}, {status:500});
   const rounded=Math.round(amountParam);
   if(!nickname||!message||!rounded) return NextResponse.json({error:'Invalid input'},{status:400});
   if(rounded<10||rounded>29999) return NextResponse.json({error:'Amount must be between 10 and 29999'},{status:400});

--- a/app/api/donations/redirect/route.ts
+++ b/app/api/donations/redirect/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { appendIntent } from '@/lib/store';
+import { appendIntent, getSetting } from '@/lib/store';
 import { buildMonoUrl, clamp, generateIdentifier, sanitizeMessage } from '@/lib/utils';
 
 export const runtime = 'nodejs';
@@ -9,9 +9,9 @@ export async function GET(req: NextRequest) {
   const nickname = (searchParams.get('nickname') || '').trim().slice(0, 64);
   const message = sanitizeMessage(searchParams.get('message') || '');
   const amountParam = Number(searchParams.get('amount') || '0');
-  const jarId = process.env.JAR_ID;
+  const jarId = await getSetting('jarId') || process.env.JAR_ID || '';
   if (!jarId) {
-    return NextResponse.json({ error: 'Server is not configured. Missing JAR_ID env var.' }, { status: 500 });
+    return NextResponse.json({ error: 'Server is not configured. Missing jarId.' }, { status: 500 });
   }
   const rounded = Math.round(amountParam);
   if (!nickname || !message || !rounded) {

--- a/app/api/monobank/status/route.ts
+++ b/app/api/monobank/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { listDonationEvents } from '@/lib/store';
 import { configureWebhook } from '@/lib/monobank-webhook';
-import type { DonationEvent } from '@/lib/utils';
+import type { DonationEvent } from '@prisma/client';
 
 export const runtime = 'nodejs';
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/lib/monobank-webhook.ts
+++ b/lib/monobank-webhook.ts
@@ -1,5 +1,7 @@
+import { getSetting } from '@/lib/store';
+
 export async function configureWebhook(webhookUrl: string): Promise<void> {
-  const token = process.env.MONOBANK_TOKEN;
+  const token = await getSetting('monobankToken') || process.env.MONOBANK_TOKEN;
   if (!token) return;
   const res = await fetch('https://api.monobank.ua/personal/webhook', {
     method: 'POST',

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,75 +1,46 @@
-import { promises as fs } from "fs";
-import path from "path";
-import type { DonationIntent, DonationEvent } from "@/lib/utils";
+import { prisma } from '@/lib/db';
+import type { DonationIntent, DonationEvent, Setting } from '@prisma/client';
 
-const dataDir = path.join(process.cwd(), "data");
-const intentsPath = path.join(dataDir, "intents.json");
-const eventsPath = path.join(dataDir, "donations.json");
-
-const locks = new Map<string, Promise<unknown>>();
-
-async function withLock<T>(file: string, task: () => Promise<T>): Promise<T> {
-  const previous = locks.get(file) ?? Promise.resolve();
-  const next = previous.then(task, task);
-  locks.set(file, next.catch(() => {}));
-  try {
-    return await next;
-  } finally {
-    if (locks.get(file) === next) locks.delete(file);
-  }
-}
-
-async function ensure(): Promise<void> {
-  await fs.mkdir(dataDir, { recursive: true });
-  try {
-    await fs.access(intentsPath);
-  } catch {
-    await fs.writeFile(intentsPath, "[]", "utf8");
-  }
-  try {
-    await fs.access(eventsPath);
-  } catch {
-    await fs.writeFile(eventsPath, "[]", "utf8");
-  }
-}
-
-/**
- * Append a donation intent sequentially.
- * Consider using fs.promises.appendFile or an external database for transactional writes.
- */
 export async function appendIntent(intent: DonationIntent): Promise<void> {
-  await withLock(intentsPath, async () => {
-    await ensure();
-    const intents: DonationIntent[] = JSON.parse(await fs.readFile(intentsPath, "utf8"));
-    intents.push(intent);
-    await fs.writeFile(intentsPath, JSON.stringify(intents, null, 2), "utf8");
+  await prisma.donationIntent.create({
+    data: {
+      ...intent,
+      identifier: intent.identifier.toLowerCase(),
+      createdAt: new Date(intent.createdAt),
+    },
   });
 }
 
 export async function findIntentByIdentifier(id: string): Promise<DonationIntent | undefined> {
-  return withLock(intentsPath, async () => {
-    await ensure();
-    const intents: DonationIntent[] = JSON.parse(await fs.readFile(intentsPath, "utf8"));
-    return intents.find((x) => x.identifier.toLowerCase() === id.toLowerCase());
+  const intent = await prisma.donationIntent.findUnique({
+    where: { identifier: id.toLowerCase() },
   });
+  return intent ?? undefined;
 }
 
-/**
- * Append a donation event sequentially.
- * Consider using fs.promises.appendFile or an external database for transactional writes.
- */
 export async function appendDonationEvent(event: DonationEvent): Promise<void> {
-  await withLock(eventsPath, async () => {
-    await ensure();
-    const events: DonationEvent[] = JSON.parse(await fs.readFile(eventsPath, "utf8"));
-    events.push(event);
-    await fs.writeFile(eventsPath, JSON.stringify(events, null, 2), "utf8");
+  await prisma.donationEvent.create({
+    data: {
+      ...event,
+      identifier: event.identifier.toLowerCase(),
+      createdAt: new Date(event.createdAt),
+    },
   });
 }
 
 export async function listDonationEvents(): Promise<DonationEvent[]> {
-  return withLock(eventsPath, async () => {
-    await ensure();
-    return JSON.parse(await fs.readFile(eventsPath, "utf8"));
+  return prisma.donationEvent.findMany({ orderBy: { createdAt: 'asc' } });
+}
+
+export async function getSetting(key: string): Promise<string | null> {
+  const s = await prisma.setting.findUnique({ where: { key } });
+  return s?.value ?? null;
+}
+
+export async function setSetting(key: string, value: string): Promise<Setting> {
+  return prisma.setting.upsert({
+    where: { key },
+    update: { value },
+    create: { key, value },
   });
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,5 +2,3 @@ export const clamp = (n:number,min:number,max:number)=>Math.max(min,Math.min(max
 export const generateIdentifier=():string=>{const b=(l:number)=>Array.from({length:l},()=>"ABCDEFGHJKLMNPQRSTUVWXYZ23456789"[Math.floor(Math.random()*34)]).join('');return `${b(3)}-${b(6)}`;}
 export const sanitizeMessage=(m:string)=>m.trim().slice(0,500).replace(/[\u0000-\u001F\u007F]/g,'');
 export const buildMonoUrl=(jarId:string,amount:number,msg:string)=>{let t=encodeURIComponent(msg).replace(/%28/g,'(').replace(/%29/g,')');return `https://send.monobank.ua/jar/${jarId}?a=${Math.round(amount)}&t=${t}`;}
-export type DonationIntent={identifier:string;nickname:string;message:string;amount:number;createdAt:string};
-export type DonationEvent={identifier:string;nickname:string;message:string;amount:number;monoComment:string;createdAt:string};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kitsune-donations",
       "version": "1.2.0",
       "dependencies": {
+        "@prisma/client": "5.15.0",
         "clsx": "2.1.1",
         "next": "14.2.5",
         "react": "18.3.1",
@@ -19,6 +20,7 @@
         "@types/react-dom": "18.3.0",
         "autoprefixer": "10.4.20",
         "postcss": "8.4.41",
+        "prisma": "5.15.0",
         "tailwindcss": "3.4.10",
         "tsx": "^4.20.3",
         "typescript": "5.5.4"
@@ -762,6 +764,74 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.15.0.tgz",
+      "integrity": "sha512-wPTeTjbd2Q0abOeffN7zCDCbkp9C9cF+e9HPiI64lmpehyq2TepgXE+sY7FXr7Rhbb21prLMnhXX27/E11V09w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.15.0.tgz",
+      "integrity": "sha512-QpEAOjieLPc/4sMny/WrWqtpIAmBYsgqwWlWwIctqZO0AbhQ9QcT6x2Ut3ojbDo/pFRCCA1Z1+xm2MUy7fAkZA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.15.0.tgz",
+      "integrity": "sha512-hXL5Sn9hh/ZpRKWiyPA5GbvF3laqBHKt6Vo70hYqqOhh5e0ZXDzHcdmxNvOefEFeqxra2DMz2hNbFoPvqrVe1w==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.15.0",
+        "@prisma/engines-version": "5.15.0-29.12e25d8d06f6ea5a0252864dd9a03b1bb51f3022",
+        "@prisma/fetch-engine": "5.15.0",
+        "@prisma/get-platform": "5.15.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.15.0-29.12e25d8d06f6ea5a0252864dd9a03b1bb51f3022",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.15.0-29.12e25d8d06f6ea5a0252864dd9a03b1bb51f3022.tgz",
+      "integrity": "sha512-3BEgZ41Qb4oWHz9kZNofToRvNeS4LZYaT9pienR1gWkjhky6t6K1NyeWNBkqSj2llgraUNbgMOCQPY4f7Qp5wA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.15.0.tgz",
+      "integrity": "sha512-z6AY5yyXxc20Klj7wwnfGP0iIUkVKzybqapT02zLYR/nf9ynaeN8bq73WRmi1TkLYn+DJ5Qy+JGu7hBf1pE78A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.15.0",
+        "@prisma/engines-version": "5.15.0-29.12e25d8d06f6ea5a0252864dd9a03b1bb51f3022",
+        "@prisma/get-platform": "5.15.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.15.0.tgz",
+      "integrity": "sha512-1GULDkW4+/VQb73vihxCBSc4Chc2x88MA+O40tcZFjmBzG4/fF44PaXFxUqKSFltxU9L9GIMLhh0Gfkk/pUbtg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.15.0"
       }
     },
     "node_modules/@swc/counter": {
@@ -1950,6 +2020,23 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prisma": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.15.0.tgz",
+      "integrity": "sha512-JA81ACQSCi3a7NUOgonOIkdx8PAVkO+HbUOxmd00Yb8DgIIEpr2V9+Qe/j6MLxIgWtE/OtVQ54rVjfYRbZsCfw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.15.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "test": "node --test --import tsx test/*.test.ts"
+    "test": "node --test --import tsx test/*.test.ts",
+    "migrate:json": "tsx scripts/migrate-json.ts"
   },
   "dependencies": {
     "clsx": "2.1.1",
     "next": "14.2.5",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "@prisma/client": "5.15.0"
   },
   "devDependencies": {
     "@types/node": "20.14.10",
@@ -22,6 +24,7 @@
     "postcss": "8.4.41",
     "tailwindcss": "3.4.10",
     "tsx": "^4.20.3",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "prisma": "5.15.0"
   }
 }

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "DonationIntent" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "identifier" TEXT NOT NULL,
+    "nickname" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "DonationEvent" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "identifier" TEXT NOT NULL,
+    "nickname" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "monoComment" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DonationEvent_identifier_fkey" FOREIGN KEY ("identifier") REFERENCES "DonationIntent" ("identifier") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Setting" (
+    "key" TEXT NOT NULL PRIMARY KEY,
+    "value" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DonationIntent_identifier_key" ON "DonationIntent"("identifier");
+
+-- CreateIndex
+CREATE INDEX "DonationEvent_identifier_idx" ON "DonationEvent"("identifier");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DonationEvent_identifier_createdAt_key" ON "DonationEvent"("identifier", "createdAt");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,37 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model DonationIntent {
+  id         Int      @id @default(autoincrement())
+  identifier String   @unique
+  nickname   String
+  message    String
+  amount     Int
+  createdAt  DateTime @default(now())
+  events     DonationEvent[] @relation("IntentEvents")
+}
+
+model DonationEvent {
+  id          Int      @id @default(autoincrement())
+  identifier  String
+  nickname    String
+  message     String
+  amount      Int
+  monoComment String
+  createdAt   DateTime @default(now())
+  intent      DonationIntent? @relation("IntentEvents", fields: [identifier], references: [identifier])
+
+  @@index([identifier])
+  @@unique([identifier, createdAt])
+}
+
+model Setting {
+  key   String @id
+  value String
+}

--- a/scripts/migrate-json.ts
+++ b/scripts/migrate-json.ts
@@ -1,0 +1,75 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { prisma } from '@/lib/db';
+
+interface JsonIntent {
+  identifier: string;
+  nickname: string;
+  message: string;
+  amount: number;
+  createdAt: string;
+}
+
+interface JsonEvent {
+  identifier: string;
+  nickname: string;
+  message: string;
+  amount: number;
+  monoComment: string;
+  createdAt: string;
+}
+
+async function loadJSON<T>(file: string): Promise<T[]> {
+  try {
+    return JSON.parse(await fs.readFile(file, 'utf8')) as T[];
+  } catch {
+    return [];
+  }
+}
+
+async function main() {
+  const dir = path.join(process.cwd(), 'data');
+  const intents = await loadJSON<JsonIntent>(path.join(dir, 'intents.json'));
+  const events = await loadJSON<JsonEvent>(path.join(dir, 'donations.json'));
+
+  for (const intent of intents) {
+    await prisma.donationIntent.upsert({
+      where: { identifier: intent.identifier.toLowerCase() },
+      update: {},
+      create: {
+        identifier: intent.identifier.toLowerCase(),
+        nickname: intent.nickname,
+        message: intent.message,
+        amount: intent.amount,
+        createdAt: new Date(intent.createdAt),
+      },
+    });
+  }
+
+  for (const ev of events) {
+    await prisma.donationEvent.upsert({
+      where: {
+        identifier_createdAt: {
+          identifier: ev.identifier.toLowerCase(),
+          createdAt: new Date(ev.createdAt),
+        },
+      },
+      update: {},
+      create: {
+        identifier: ev.identifier.toLowerCase(),
+        nickname: ev.nickname,
+        message: ev.message,
+        amount: ev.amount,
+        monoComment: ev.monoComment,
+        createdAt: new Date(ev.createdAt),
+      },
+    });
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary
- integrate Prisma ORM and models for donations and settings
- migrate donation store and API routes to database-backed repo
- add script to import existing JSON data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689978581dd883269b5b10096bf5203e