### PR TITLE
feat: configure monobank webhook via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ DATABASE_URL="file:./dev.db"
 JAR_ID=
 # Personal token for Monobank API to auto-configure webhook
 MONOBANK_TOKEN=
+# Public HTTPS URL for Monobank webhook
+MONOBANK_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kitsune Donations v1.2
 - `/obs` без SSR-помилок (жодних звернень до `window` під час рендеру).
 - SSE з heartbeat кожні 15с, щоб не засинав конекшн.
-- Для реального вебхука потрібен публічний HTTPS. За бажанням встановіть `MONOBANK_WEBHOOK_SECRET` і перевіряйте підпис `X-Sign`.
-- Якщо встановлено `MONOBANK_TOKEN`, ендпоінт `/api/monobank/status` автоматично реєструє вебхук на `/api/monobank/webhook`.
+- Для реального вебхука потрібен публічний HTTPS. Встановіть `MONOBANK_WEBHOOK_URL` і за бажанням `MONOBANK_WEBHOOK_SECRET` для перевірки підпису `X-Sign`.
+- Якщо встановлено `MONOBANK_TOKEN`, ендпоінт `/api/monobank/status` автоматично реєструє вебхук на адресу з `MONOBANK_WEBHOOK_URL`.
 
 Запуск: `pnpm i && cp .env.example .env.local && pnpm dev`

--- a/app/api/monobank/status/route.ts
+++ b/app/api/monobank/status/route.ts
@@ -10,13 +10,11 @@ interface StatusResponse {
   event: DonationEvent | null;
 }
 
-export async function GET(request: Request) {
+export async function GET() {
   try {
     try {
-      const requestURL = request.url;
-      await configureWebhook(
-        new URL('/api/monobank/webhook', requestURL).href,
-      );
+      const webhookUrl = process.env.MONOBANK_WEBHOOK_URL;
+      if (webhookUrl) await configureWebhook(webhookUrl);
     } catch (err) {
       console.error('Failed to configure Monobank webhook', err);
     }


### PR DESCRIPTION
## Summary
- add `MONOBANK_WEBHOOK_URL` env variable
- register Monobank webhook using configured URL
- document webhook URL requirement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998a246194832685f96e9576714691