### PR TITLE
Handle Monobank webhook URL check failures

### DIFF
--- a/lib/monobank-webhook.ts
+++ b/lib/monobank-webhook.ts
@@ -13,9 +13,15 @@ export async function configureWebhook(webhookUrl: string): Promise<void> {
   });
   const details = await res.text();
   if (res.ok) return;
-  if (res.status === 400 && /already/i.test(details)) {
-    console.warn(`Monobank webhook already configured: ${details}`);
-    return;
+  if (res.status === 400) {
+    if (/already/i.test(details)) {
+      console.warn(`Monobank webhook already configured: ${details}`);
+      return;
+    }
+    if (/check webHookUrl failed/i.test(details)) {
+      console.warn(`Monobank webhook URL check failed: ${details}`);
+      return;
+    }
   }
   throw new Error(
     `Failed to configure Monobank webhook: ${res.status} ${details}`,

--- a/test/monobank-webhook-config.test.ts
+++ b/test/monobank-webhook-config.test.ts
@@ -52,3 +52,13 @@ test('warns if webhook already configured', async (t) => {
   await configureWebhook('https://example.com/hook');
   assert.strictEqual(warnMock.mock.calls.length, 1);
 });
+
+test('warns if webhook URL check fails', async (t) => {
+  await setupToken();
+  t.mock.method(globalThis, 'fetch', async () =>
+    new Response('Check webHookUrl failed', { status: 400 }),
+  );
+  const warnMock = t.mock.method(console, 'warn', () => {});
+  await configureWebhook('https://example.com/hook');
+  assert.strictEqual(warnMock.mock.calls.length, 1);
+});


### PR DESCRIPTION
## Summary
- warn on Monobank "Check webHookUrl failed" responses rather than throwing
- cover webhook URL check failures in unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689996cf7c708326904a340645027e0f