### PR TITLE
feat: align login page with home

### DIFF
--- a/app/login/login-button.tsx
+++ b/app/login/login-button.tsx
@@ -1,10 +1,26 @@
 'use client';
 import { signIn } from 'next-auth/react';
-import { Button } from '@/components/ui/button';
 
 export function LoginButton() {
   function handleLogin() {
     signIn('twitch');
   }
-  return <Button onClick={handleLogin}>Sign in with Twitch</Button>;
+  return (
+    <button
+      type="button"
+      onClick={handleLogin}
+      className="btn-primary inline-flex items-center gap-2"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-5 h-5"
+      >
+        <path d="M4.265 0L0 4.265v15.47h6.352V24l4.265-4.265h5.412L24 11.824V0H4.265zm17.647 11.824-3.706 3.706h-5.647l-3.529 3.53v-3.53H3.176V2.118h18.736v9.706z" />
+        <path d="M13.765 5.882h2.118v5.647h-2.118zm-4.235 0h2.118v5.647H9.53z" />
+      </svg>
+      Sign in with Twitch
+    </button>
+  );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,10 +3,18 @@ import { LoginButton } from './login-button';
 
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center p-4">
-      <Suspense fallback={<p>Loading…</p>}>
-        <LoginButton />
-      </Suspense>
+    <main className="min-h-screen relative overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-40 -left-40 h-[36rem] w-[36rem] rounded-full bg-fuchsia-600/20 blur-3xl" />
+        <div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl" />
+      </div>
+      <div className="relative mx-auto max-w-2xl px-6 py-14">
+        <div className="card p-6 md:p-8 flex justify-center">
+          <Suspense fallback={<p>Loading…</p>}>
+            <LoginButton />
+          </Suspense>
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Match login page layout to home with gradient background and centered card
- Switch login button to Tailwind-styled button with Twitch icon

## Testing
- `npm test` *(fails: import_client.PrismaClient is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_6899a29c0bf88326a46b4cbb09b72954