### PR TITLE
Persist Monobank settings in database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,7 @@
 # SQLite connection for Prisma
 DATABASE_URL="file:./dev.db"
-# Monobank jar identifier
-JAR_ID=
-# Personal token for Monobank API to auto-configure webhook
-MONOBANK_TOKEN=
-# Public HTTPS URL for Monobank webhook
-MONOBANK_WEBHOOK_URL=
+# Secret for verifying Monobank webhook signatures
+MONOBANK_WEBHOOK_SECRET=
 TWITCH_CLIENT_ID=
 TWITCH_CLIENT_SECRET=
 NEXTAUTH_SECRET=

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Kitsune Donations v1.2
 - `/obs` без SSR-помилок (жодних звернень до `window` під час рендеру).
 - SSE з heartbeat кожні 15с, щоб не засинав конекшн.
-- Для реального вебхука потрібен публічний HTTPS. Встановіть `MONOBANK_WEBHOOK_URL` і за бажанням `MONOBANK_WEBHOOK_SECRET` для перевірки підпису `X-Sign`.
-- Якщо встановлено `MONOBANK_TOKEN`, ендпоінт `/api/monobank/status` автоматично реєструє вебхук на адресу з `MONOBANK_WEBHOOK_URL`.
+- Для реального вебхука потрібен публічний HTTPS. За бажанням встановіть `MONOBANK_WEBHOOK_SECRET` для перевірки підпису `X-Sign`.
 
 Запуск: `pnpm i && cp .env.example .env.local && pnpm dev`

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { getSetting, setSetting } from '@/lib/store';
+import { Button } from '@/components/ui/button';
+
+export default async function SettingsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'admin') redirect('/login');
+
+  const [jarId, monobankToken] = await Promise.all([
+    getSetting('jarId'),
+    getSetting('monobankToken'),
+  ]);
+
+  async function save(formData: FormData) {
+    'use server';
+    const jar = formData.get('jarId')?.toString().trim() ?? '';
+    const token = formData.get('monobankToken')?.toString().trim() ?? '';
+    await Promise.all([
+      setSetting('jarId', jar),
+      setSetting('monobankToken', token),
+    ]);
+    redirect('/admin/settings');
+  }
+
+  return (
+    <main className="min-h-screen relative overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-40 -left-40 h-[36rem] w-[36rem] rounded-full bg-fuchsia-600/20 blur-3xl" />
+        <div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl" />
+      </div>
+      <div className="relative mx-auto max-w-2xl px-6 py-14">
+        <header className="mb-8 text-center">
+          <h1 className="text-4xl md:text-5xl font-extrabold title-gradient drop-shadow-sm">Admin</h1>
+          <div className="mt-3 badge">Settings</div>
+        </header>
+        <form action={save} className="card p-6 md:p-8 grid gap-6">
+          <div className="grid gap-2">
+            <label htmlFor="jarId" className="text-sm text-neutral-300">Jar ID</label>
+            <input id="jarId" name="jarId" defaultValue={jarId ?? ''} className="input-base" required />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="monobankToken" className="text-sm text-neutral-300">Monobank token</label>
+            <input id="monobankToken" name="monobankToken" defaultValue={monobankToken ?? ''} className="input-base" required />
+          </div>
+          <Button type="submit" className="w-full">Save</Button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/app/api/donations/create/route.ts
+++ b/app/api/donations/create/route.ts
@@ -1,20 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { appendIntent, getSetting } from '@/lib/store';
 import { buildMonoUrl, clamp, generateIdentifier, sanitizeMessage } from '@/lib/utils';
-export const runtime='nodejs';
-export async function GET(req: NextRequest){
-  const sp=new URL(req.url).searchParams;
-  const nickname=(sp.get('nickname')||'').trim().slice(0,64);
-  const message=sanitizeMessage(sp.get('message')||'');
-  const amountParam=Number(sp.get('amount')||'0');
-  const jarId=await getSetting('jarId')||process.env.JAR_ID||'';
-  if(!jarId) return NextResponse.json({error:'Missing jarId'}, {status:500});
-  const rounded=Math.round(amountParam);
-  if(!nickname||!message||!rounded) return NextResponse.json({error:'Invalid input'},{status:400});
-  if(rounded<10||rounded>29999) return NextResponse.json({error:'Amount must be between 10 and 29999'},{status:400});
-  const amount=clamp(rounded,10,29999);
-  const identifier=generateIdentifier();
-  await appendIntent({identifier,nickname,message,amount,createdAt:new Date().toISOString()});
-  const url=buildMonoUrl(jarId,amount,`${message} (${identifier.toLowerCase()})`);
-  return NextResponse.json({ok:true,url,identifier},{headers:{'Referrer-Policy':'no-referrer'}});
+
+export const runtime = 'nodejs';
+
+export async function GET(req: NextRequest) {
+  const sp = new URL(req.url).searchParams;
+  const nickname = (sp.get('nickname') || '').trim().slice(0, 64);
+  const message = sanitizeMessage(sp.get('message') || '');
+  const amountParam = Number(sp.get('amount') || '0');
+  const jarId = await getSetting('jarId');
+  if (!jarId) return NextResponse.json({ error: 'Missing jarId' }, { status: 500 });
+  const rounded = Math.round(amountParam);
+  if (!nickname || !message || !rounded) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+  if (rounded < 10 || rounded > 29999) return NextResponse.json({ error: 'Amount must be between 10 and 29999' }, { status: 400 });
+  const amount = clamp(rounded, 10, 29999);
+  const identifier = generateIdentifier();
+  await appendIntent({ identifier, nickname, message, amount, createdAt: new Date().toISOString() });
+  const url = buildMonoUrl(jarId, amount, `${message} (${identifier.toLowerCase()})`);
+  return NextResponse.json({ ok: true, url, identifier }, { headers: { 'Referrer-Policy': 'no-referrer' } });
 }

--- a/app/api/donations/redirect/route.ts
+++ b/app/api/donations/redirect/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest) {
   const nickname = (searchParams.get('nickname') || '').trim().slice(0, 64);
   const message = sanitizeMessage(searchParams.get('message') || '');
   const amountParam = Number(searchParams.get('amount') || '0');
-  const jarId = await getSetting('jarId') || process.env.JAR_ID || '';
+  const jarId = await getSetting('jarId');
   if (!jarId) {
     return NextResponse.json({ error: 'Server is not configured. Missing jarId.' }, { status: 500 });
   }

--- a/app/api/monobank/status/route.ts
+++ b/app/api/monobank/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getSetting, listDonationEvents, setSetting } from '@/lib/store';
+import { getSetting, listDonationEvents } from '@/lib/store';
 import { configureWebhook } from '@/lib/monobank-webhook';
 import type { DonationEvent } from '@prisma/client';
 
@@ -13,14 +13,8 @@ interface StatusResponse {
 export async function GET() {
   try {
     try {
-      const webhookUrl = process.env.MONOBANK_WEBHOOK_URL;
-      if (webhookUrl) {
-        const currentUrl = await getSetting('monobankWebhookUrl');
-        if (currentUrl !== webhookUrl) {
-          await configureWebhook(webhookUrl);
-          await setSetting('monobankWebhookUrl', webhookUrl);
-        }
-      }
+      const webhookUrl = await getSetting('monobankWebhookUrl');
+      if (webhookUrl) await configureWebhook(webhookUrl);
     } catch (err) {
       console.error('Failed to configure Monobank webhook', err);
     }

--- a/lib/monobank-webhook.ts
+++ b/lib/monobank-webhook.ts
@@ -1,7 +1,7 @@
 import { getSetting } from '@/lib/store';
 
 export async function configureWebhook(webhookUrl: string): Promise<void> {
-  const token = await getSetting('monobankToken') || process.env.MONOBANK_TOKEN;
+  const token = await getSetting('monobankToken');
   if (!token) return;
   const res = await fetch('https://api.monobank.ua/personal/webhook', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- type-safe settings helpers for jarId and Monobank token
- admin settings page to update jarId and token
- API routes now read settings from database only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899a8750bd0832697c15974f5e1a070