### PR TITLE
feat(auth): mark twitch users as streamer

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -13,6 +13,10 @@ export const authOptions: NextAuthOptions = {
   ],
   session: { strategy: 'database' },
   callbacks: {
+    async signIn({ user, account }) {
+      if (account?.provider === 'twitch') user.role = 'streamer';
+      return true;
+    },
     async session({ session, user }) {
       if (session.user) session.user.role = (user as any).role;
       return session;


### PR DESCRIPTION
## Summary
- assign `streamer` role when signing in via Twitch
- ensure session exposes the user's role

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899dc3bcc2883268c1e20a8c088a2d5