### PR TITLE
feat: manage user roles from admin dashboard

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,15 +1,55 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { RoleSelect } from './role-select';
 
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'admin') redirect('/admin/login');
 
+  const users = await prisma.user.findMany({
+    where: { accounts: { some: { provider: 'twitch' } } },
+    select: { id: true, name: true, email: true, role: true },
+  });
+
   return (
     <main className="mx-auto max-w-2xl p-6">
       <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+      <UserTable users={users} />
     </main>
   );
+}
+
+function UserTable({ users }: { users: User[] }) {
+  return (
+    <table className="mt-6 w-full text-sm">
+      <thead className="text-left">
+        <tr>
+          <th className="pb-2">Name</th>
+          <th className="pb-2">Email</th>
+          <th className="pb-2">Role</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-neutral-700">
+        {users.map((user) => (
+          <tr key={user.id} className="h-10">
+            <td className="pr-4">{user.name}</td>
+            <td className="pr-4">{user.email}</td>
+            <td>
+              <RoleSelect userId={user.id} initialRole={user.role} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+interface User {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: string;
 }
 

--- a/app/admin/role-select.tsx
+++ b/app/admin/role-select.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+interface RoleSelectProps {
+  userId: string;
+  initialRole: string;
+}
+
+export function RoleSelect({ userId, initialRole }: RoleSelectProps) {
+  const [role, setRole] = useState(initialRole);
+  const [isPending, startTransition] = useTransition();
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const nextRole = e.target.value;
+    setRole(nextRole);
+    startTransition(async () => {
+      await fetch(`/api/users/${userId}/role`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: nextRole }),
+      });
+    });
+  }
+
+  return (
+    <select
+      value={role}
+      onChange={handleChange}
+      disabled={isPending}
+      className="rounded-md border border-neutral-700 bg-transparent p-1"
+    >
+      <option value="streamer">streamer</option>
+      <option value="admin">admin</option>
+    </select>
+  );
+}
+

--- a/app/api/users/[id]/role/route.ts
+++ b/app/api/users/[id]/role/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+
+interface RoleBody {
+  role: string;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'admin')
+    return new NextResponse('Unauthorized', { status: 401 });
+
+  const body: RoleBody = await req.json();
+
+  const user = await prisma.user.update({
+    where: { id: params.id },
+    data: { role: body.role },
+    select: { id: true, role: true },
+  });
+
+  return NextResponse.json(user);
+}
+


### PR DESCRIPTION
## Summary
- list Twitch users on admin dashboard with role controls
- add RoleSelect client component for updating user roles
- expose secured API endpoint to persist role changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e7b5a3948326b05e65f1ce799cc8