### PR TITLE
Redirect streamers to panel after Twitch login

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth/next';
 import Credentials from 'next-auth/providers/credentials';
 import Twitch from 'next-auth/providers/twitch';
 import { prisma } from './db';
+import { createRedirect } from './redirect';
 
 export const authOptions = {
   adapter: PrismaAdapter(prisma),
@@ -41,6 +42,7 @@ export const authOptions = {
       if (session.user && user.role) session.user.role = user.role;
       return session;
     },
+    redirect: createRedirect(getAuthSession),
   },
 };
 

--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -1,0 +1,14 @@
+export interface RedirectContext {
+  url: string;
+  baseUrl: string;
+}
+
+export function createRedirect(
+  getSession: () => Promise<any>
+): (ctx: RedirectContext) => Promise<string> {
+  return async function redirect({ url, baseUrl }: RedirectContext) {
+    const session = await getSession();
+    if (session?.user?.role === 'streamer') return `${baseUrl}/panel`;
+    return url.startsWith(baseUrl) ? url : baseUrl;
+  };
+}

--- a/test/auth-redirect.test.ts
+++ b/test/auth-redirect.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createRedirect } from '../lib/redirect';
+
+test('redirects streamer to panel', async () => {
+  const redirect = createRedirect(async () => ({
+    user: { role: 'streamer' },
+  }));
+  const url = await redirect({
+    url: 'http://localhost:3000',
+    baseUrl: 'http://localhost:3000',
+  });
+  assert.strictEqual(url, 'http://localhost:3000/panel');
+});


### PR DESCRIPTION
## Summary
- redirect streamers to `/panel` via auth redirect callback
- cover redirect behavior with a dedicated test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ea5cdd7c83269aa8af2458f507e0