### PR TITLE
refactor: rename amount presets component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useMemo } from 'react'; import Link from 'next/link'; import { AmountPresets } from '@/components/AmountPresets';
+import { useState, useMemo } from 'react'; import Link from 'next/link'; import { AmountPresets } from '@/components/amount-presets';
 export default function HomePage(){
   const [nickname,setNickname]=useState(''); const [amount,setAmount]=useState<number>(50); const [message,setMessage]=useState(''); const [submitting,setSubmitting]=useState(false); const [testing,setTesting]=useState(false); const [error,setError]=useState(''); const [toast,setToast]=useState('');
   const isAmountValid=amount>=10&&amount<=29999;

--- a/components/AmountPresets.tsx
+++ b/components/AmountPresets.tsx
@@ -1,2 +1,0 @@
-'use client'; import { clsx } from 'clsx'; type Props={value:number;onChange:(n:number)=>void}; const presets=[20,50,100,200];
-export function AmountPresets({value,onChange}:Props){return(<div className="flex flex-wrap gap-3">{presets.map(p=>(<button key={p} type="button" aria-label={`Обрати ${p} гривень`} className={clsx('pill', value===p && 'ring-2 ring-purple-400')} onClick={()=>onChange(p)}>{p}</button>))}</div>);}

--- a/components/amount-presets.tsx
+++ b/components/amount-presets.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { clsx } from 'clsx';
+
+export function AmountPresets({ value, onChange }: AmountPresetsProps) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {presets.map(preset => (
+        <button
+          key={preset}
+          type="button"
+          aria-label={`Обрати ${preset} гривень`}
+          className={clsx('pill', value === preset && 'ring-2 ring-purple-400')}
+          onClick={() => onChange(preset)}
+        >
+          {preset}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const presets = [50, 100, 200, 500];
+
+interface AmountPresetsProps {
+  value: number;
+  onChange: (n: number) => void;
+}
+


### PR DESCRIPTION
## Summary
- rename `AmountPresets` to `amount-presets`
- expand component with typed props and update preset values
- fix imports for new component path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a3ac3f8308326b39aac3bfcfa2905