### PR TITLE
refactor: expand utility helpers

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,50 @@
-export const clamp = (n:number,min:number,max:number)=>Math.max(min,Math.min(max,n));
-export const generateIdentifier=():string=>{const b=(l:number)=>Array.from({length:l},()=>"ABCDEFGHJKLMNPQRSTUVWXYZ23456789"[Math.floor(Math.random()*34)]).join('');return `${b(3)}-${b(6)}`;}
-export const sanitizeMessage=(m:string)=>m.trim().slice(0,500).replace(/[\u0000-\u001F\u007F]/g,'');
-export const buildMonoUrl=(jarId:string,amount:number,msg:string)=>{let t=encodeURIComponent(msg).replace(/%28/g,'(').replace(/%29/g,')');return `https://send.monobank.ua/jar/${jarId}?a=${Math.round(amount)}&t=${t}`;}
+/**
+ * Restrict a number within bounds.
+ *
+ * @param n - candidate value
+ * @param min - lower bound
+ * @param max - upper bound
+ * @returns bounded value
+ */
+export function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n))
+}
+
+/**
+ * Generate an identifier formatted as `XXX-XXXXXX`.
+ *
+ * @returns random identifier
+ */
+export function generateIdentifier(): string {
+  function block(length: number): string {
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+    return Array.from({ length }, () => chars[Math.floor(Math.random() * chars.length)]).join('')
+  }
+
+  return `${block(3)}-${block(6)}`
+}
+
+/**
+ * Normalize user-provided messages.
+ *
+ * Trims whitespace, limits length to 500 characters and strips control characters.
+ *
+ * @param message - raw input
+ * @returns sanitized message
+ */
+export function sanitizeMessage(message: string): string {
+  return message.trim().slice(0, 500).replace(/[\u0000-\u001F\u007F]/g, '')
+}
+
+/**
+ * Construct a Monobank donation URL.
+ *
+ * @param jarId - target jar identifier
+ * @param amount - donation amount
+ * @param message - message to encode
+ * @returns Monobank donation URL
+ */
+export function buildMonoUrl(jarId: string, amount: number, message: string): string {
+  const encoded = encodeURIComponent(message)
+  return `https://send.monobank.ua/jar/${jarId}?a=${Math.round(amount)}&t=${encoded}`
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,22 @@
 import test from 'node:test'
 import assert from 'node:assert'
-import { buildMonoUrl } from '../lib/utils.ts'
+import { buildMonoUrl, clamp, sanitizeMessage } from '../lib/utils.ts'
 
 test('buildMonoUrl encodes message', () => {
   const url = buildMonoUrl('JAR', 50, 'Hello world (foo) & bar')
   assert.strictEqual(url, 'https://send.monobank.ua/jar/JAR?a=50&t=Hello%20world%20(foo)%20%26%20bar')
+})
+
+test('clamp constrains numbers within range', () => {
+  assert.strictEqual(clamp(5, 0, 10), 5)
+  assert.strictEqual(clamp(-5, 0, 10), 0)
+  assert.strictEqual(clamp(15, 0, 10), 10)
+})
+
+test('sanitizeMessage trims, truncates and strips control characters', () => {
+  const cleaned = sanitizeMessage(' \u0000hello\u0001 world\u007F ')
+  assert.strictEqual(cleaned, 'hello world')
+
+  const long = 'a'.repeat(600)
+  assert.strictEqual(sanitizeMessage(long).length, 500)
 })


### PR DESCRIPTION
## Summary
- refactor donation utilities into documented multi-line functions
- encode special characters in `buildMonoUrl`
- cover utility helpers with tests

## Testing
- `node --test --test-concurrency=1 --import tsx test/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a3c3c0b108326a68495cbcc853b7c