### PR TITLE
feat: add donation form component and auth landing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,29 @@
-'use client';
-import { useState, useMemo } from 'react'; import Link from 'next/link'; import { AmountPresets } from '@/components/amount-presets';
-export default function HomePage(){
-  const [nickname,setNickname]=useState(''); const [amount,setAmount]=useState<number>(50); const [message,setMessage]=useState(''); const [submitting,setSubmitting]=useState(false); const [testing,setTesting]=useState(false); const [error,setError]=useState(''); const [toast,setToast]=useState('');
-  const isAmountValid=amount>=10&&amount<=29999;
-  const isValid=useMemo(()=>{ if(!nickname.trim()||!message.trim()) return false; if(!Number.isFinite(amount)) return false; if(!isAmountValid) return false; return true; },[nickname,amount,message,isAmountValid]);
-  const showToast=(t:string)=>{setToast(t); setTimeout(()=>setToast(''),3000)};
-  const openInNewTabNoRef=(url:string)=>{const a=document.createElement('a'); a.href=url; a.target='_blank'; a.rel='noopener noreferrer'; a.referrerPolicy='no-referrer'; a.style.display='none'; document.body.appendChild(a); a.click(); a.remove();};
-  const handleSubmit=async(e:React.FormEvent)=>{e.preventDefault(); if(!isValid||submitting) return; setSubmitting(true); setError(''); try{ const qs=new URLSearchParams({nickname:nickname.trim(), amount:String(Math.round(amount)), message:message.trim().slice(0,500)}); const r=await fetch(`/api/donations/create?${qs.toString()}`,{cache:'no-store'}); const d=await r.json(); if(!r.ok||!d?.url) throw new Error(d?.error||'Помилка'); openInNewTabNoRef(d.url); showToast('Відкрито банку в новій вкладці'); }catch{ setError('Сталася помилка. Спробуйте ще раз.'); } finally{ setSubmitting(false);} };
-  const handleTest=async()=>{ if(testing) return; setTesting(true); try{ const b={nickname:nickname.trim()||'kitsune_fan', amount:Math.round(amount)||50, message:message.trim()||'Тест повідомлення'}; const r=await fetch('/api/test',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(b)}); if(!r.ok) throw new Error(); showToast('Надіслано тест сповіщення в OBS'); }catch{ showToast('Не вдалося надіслати тест'); } finally{ setTesting(false);} };
-  return(<main className="min-h-screen relative overflow-hidden"><div className="pointer-events-none absolute inset-0"><div className="absolute -top-40 -left-40 h-[36rem] w-[36rem] rounded-full bg-fuchsia-600/20 blur-3xl"/><div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl"/></div><div className="relative mx-auto max-w-2xl px-6 py-14"><header className="mb-8 text-center"><h1 className="text-4xl md:text-5xl font-extrabold title-gradient drop-shadow-sm">Підтримати Kitsune</h1><div className="mt-3 badge">Безпечно через Monobank</div></header><form onSubmit={handleSubmit} className="card p-6 md:p-8 grid gap-6" aria-label="Форма донату"><div><label className="block mb-2 text-sm text-neutral-300">Сума</label><div className="flex gap-3 items-center"><input type="number" inputMode="numeric" min={10} max={29999} step={1} value={amount} onChange={(e)=>setAmount(Number(e.target.value))} className="input-base text-lg" aria-describedby="amount-hint" aria-label="Сума донату" required/><span className="pill flex flex-col items-center justify-center min-w-[80px] text-sm"><span>₴</span><span className="text-neutral-300">UAH</span></span></div><p id="amount-hint" className="mt-2 text-xs text-neutral-400">Сума від 10 до 29999 ₴</p>{!isAmountValid&&<p className="mt-2 text-xs text-rose-400">Сума має бути від 10 до 29999 ₴</p>}<div className="mt-3"><AmountPresets value={amount} onChange={setAmount}/></div></div><div className="grid gap-2"><label className="text-sm text-neutral-300">Ім&apos;я</label><input type="text" value={nickname} onChange={(e)=>setNickname(e.target.value)} placeholder="ваш нікнейм" className="input-base" aria-label="Нікнейм" required/></div><div className="grid gap-2"><label className="text-sm text-neutral-300">Повідомлення</label><textarea value={message} onChange={(e)=>setMessage(e.target.value)} placeholder="ваше повідомлення (макс. 500 символів)" className="input-base min-h-[120px] resize-y" maxLength={500} aria-label="Повідомлення" required/><p className="text-xs text-neutral-500">Максимум символів – 500</p></div>{error&&<p className="text-rose-400 text-sm">{error}</p>}<div className="grid sm:grid-cols-2 gap-3"><button type="submit" className="btn-primary w-full text-lg" disabled={!isValid||submitting} aria-label="Надіслати донат">{submitting?'Готуємо посилання…':'Надіслати'}</button><button type="button" className="btn-ghost w-full text-lg" onClick={handleTest} aria-label="Надіслати тест до OBS" disabled={testing}>{testing?'Тест…':'Тест сповіщення'}</button></div><div className="text-xs text-neutral-400 text-center">Посилання на банку відкриється у новій вкладці без реферера. Післядонату ваш нік, сума і повідомлення з’являться в OBS.</div></form><Link href="/login" className="mt-6 flex justify-center"><button type="button" className="btn-primary inline-flex items-center gap-2"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5"><path d="M4.265 0L0 4.265v15.47h6.352V24l4.265-4.265h5.412L24 11.824V0H4.265zm17.647 11.824-3.706 3.706h-5.647l-3.529 3.53v-3.53H3.176V2.118h18.736v9.706z"/><path d="M13.765 5.882h2.118v5.647h-2.118zm-4.235 0h2.118v5.647H9.53z"/></svg>Sign in with Twitch</button></Link>{toast&&(<div className="fixed left-1/2 -translate-x-1/2 bottom-6 z-50"><div className="rounded-full bg-white/10 ring-1 ring-white/20 px-4 py-2 text-sm shadow-lg">{toast}</div></div>)}</div></main>);
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export default async function HomePage() {
+  const session = await getServerSession(authOptions);
+  if (session) redirect('/panel');
+
+  return (
+    <main className="min-h-screen relative overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-40 -left-40 h-[36rem] w-[36rem] rounded-full bg-fuchsia-600/20 blur-3xl" />
+        <div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl" />
+      </div>
+      <div className="relative mx-auto max-w-2xl px-6 py-14">
+        <div className="card p-6 md:p-8 flex flex-col gap-4">
+          <Link href="/login" className="btn-primary text-center">
+            Створити сторінку
+          </Link>
+          <Link href="/panel" className="btn-ghost text-center">
+            Увійти
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
 }
+

--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQueryState, parseAsInteger, parseAsString } from 'nuqs';
+import { AmountPresets } from './amount-presets';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+
+export function DonationForm(_: DonationFormProps) {
+  const [nickname, setNickname] = useQueryState('nickname', parseAsString.withDefault(''));
+  const [amount, setAmount] = useQueryState('amount', parseAsInteger.withDefault(50));
+  const [message, setMessage] = useQueryState('message', parseAsString.withDefault(''));
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [youtubeInput, setYoutubeInput] = useState('');
+  const [youtube, setYoutube] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [error, setError] = useState('');
+  const [toast, setToast] = useState('');
+
+  const isAmountValid = amount >= 10 && amount <= 29999;
+  const isValid = useMemo(() => {
+    if (!nickname.trim() || !message.trim()) return false;
+    if (!Number.isFinite(amount)) return false;
+    if (!isAmountValid) return false;
+    return true;
+  }, [nickname, amount, message, isAmountValid]);
+
+  function showToast(text: string) {
+    setToast(text);
+    setTimeout(() => setToast(''), 3000);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isValid || submitting) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const params = new URLSearchParams({
+        nickname: nickname.trim(),
+        amount: String(Math.round(amount)),
+        message: message.trim().slice(0, 500),
+      });
+      if (youtube) params.set('youtube', youtube);
+      const res = await fetch(`/api/donations/create?${params}`, { cache: 'no-store' });
+      const data = await res.json();
+      if (!res.ok || !data?.url) throw new Error(data?.error || 'Помилка');
+      window.open(data.url, '_blank', 'noopener,noreferrer');
+      showToast('Відкрито банку в новій вкладці');
+    } catch {
+      setError('Сталася помилка. Спробуйте ще раз.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleTest() {
+    if (testing) return;
+    setTesting(true);
+    try {
+      const body = {
+        nickname: nickname.trim() || 'kitsune_fan',
+        amount: Math.round(amount) || 50,
+        message: message.trim() || 'Тест повідомлення',
+      };
+      const res = await fetch('/api/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error();
+      showToast('Надіслано тест сповіщення в OBS');
+    } catch {
+      showToast('Не вдалося надіслати тест');
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  const videoId = extractYoutubeId(youtubeInput);
+  const embed = videoId ? `https://www.youtube.com/embed/${videoId}` : '';
+
+  function handleAttach() {
+    if (embed) setYoutube(embed);
+    setDialogOpen(false);
+  }
+
+  function handleClear() {
+    setYoutube('');
+    setYoutubeInput('');
+    setDialogOpen(false);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="card p-6 md:p-8 grid gap-6" aria-label="Форма донату">
+      <div>
+        <label className="block mb-2 text-sm text-neutral-300">Сума</label>
+        <div className="flex gap-3 items-center">
+          <input
+            type="number"
+            inputMode="numeric"
+            min={10}
+            max={29999}
+            step={1}
+            value={amount}
+            onChange={e => setAmount(Number(e.target.value))}
+            className="input-base text-lg"
+            aria-describedby="amount-hint"
+            aria-label="Сума донату"
+            required
+          />
+          <span className="pill flex flex-col items-center justify-center min-w-[80px] text-sm">
+            <span>₴</span>
+            <span className="text-neutral-300">UAH</span>
+          </span>
+        </div>
+        <p id="amount-hint" className="mt-2 text-xs text-neutral-400">Сума від 10 до 29999 ₴</p>
+        {!isAmountValid && <p className="mt-2 text-xs text-rose-400">Сума має бути від 10 до 29999 ₴</p>}
+        <div className="mt-3">
+          <AmountPresets value={amount} onChange={setAmount} />
+        </div>
+      </div>
+      <div className="grid gap-2">
+        <label className="text-sm text-neutral-300">Ім&apos;я</label>
+        <input
+          type="text"
+          value={nickname}
+          onChange={e => setNickname(e.target.value)}
+          placeholder="ваш нікнейм"
+          className="input-base"
+          aria-label="Нікнейм"
+          required
+        />
+      </div>
+      <div className="grid gap-2">
+        <label className="text-sm text-neutral-300">Повідомлення</label>
+        <textarea
+          value={message}
+          onChange={e => setMessage(e.target.value)}
+          placeholder="ваше повідомлення (макс. 500 символів)"
+          className="input-base min-h-[120px] resize-y"
+          maxLength={500}
+          aria-label="Повідомлення"
+          required
+        />
+        <p className="text-xs text-neutral-500">Максимум символів – 500</p>
+      </div>
+      <div className="flex gap-3">
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button type="button" variant="outline">YouTube</Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Посилання на YouTube</DialogTitle>
+            </DialogHeader>
+            <input
+              className="input-base w-full mt-4"
+              placeholder="https://youtu.be/..."
+              value={youtubeInput}
+              onChange={e => setYoutubeInput(e.target.value)}
+            />
+            {embed && (
+              <div className="mt-4 aspect-video">
+                <iframe
+                  src={embed}
+                  className="w-full h-full rounded-md"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                />
+              </div>
+            )}
+            <DialogFooter className="mt-4 gap-2">
+              <Button type="button" onClick={handleAttach} disabled={!embed}>Прикріпити</Button>
+              <Button type="button" variant="outline" onClick={handleClear}>Очистити</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+      {youtube && (
+        <div className="aspect-video">
+          <iframe
+            src={youtube}
+            className="w-full h-full rounded-md"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+      )}
+      {error && <p className="text-rose-400 text-sm">{error}</p>}
+      <div className="grid sm:grid-cols-2 gap-3">
+        <button
+          type="submit"
+          className="btn-primary w-full text-lg"
+          disabled={!isValid || submitting}
+          aria-label="Надіслати донат"
+        >
+          {submitting ? 'Готуємо посилання…' : 'Надіслати'}
+        </button>
+        <button
+          type="button"
+          className="btn-ghost w-full text-lg"
+          onClick={handleTest}
+          aria-label="Надіслати тест до OBS"
+          disabled={testing}
+        >
+          {testing ? 'Тест…' : 'Тест сповіщення'}
+        </button>
+      </div>
+      <div className="text-xs text-neutral-400 text-center">
+        Посилання на банку відкриється у новій вкладці без реферера. Після донату ваш нік, сума і повідомлення з’являться в OBS.
+      </div>
+      {toast && (
+        <div className="fixed left-1/2 -translate-x-1/2 bottom-6 z-50">
+          <div className="rounded-full bg-white/10 ring-1 ring-white/20 px-4 py-2 text-sm shadow-lg">
+            {toast}
+          </div>
+        </div>
+      )}
+    </form>
+  );
+}
+
+function extractYoutubeId(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (u.hostname === 'youtu.be') return u.pathname.slice(1);
+    if (u.hostname.endsWith('youtube.com')) {
+      if (u.pathname === '/watch') return u.searchParams.get('v');
+      if (u.pathname.startsWith('/embed/')) return u.pathname.split('/')[2];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface DonationFormProps {}
+

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { clsx } from 'clsx';
+
+function cn(...classes: unknown[]): string {
+  return clsx(classes);
+}
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogClose = DialogPrimitive.Close;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn('fixed inset-0 z-50 bg-black/80', className)}
+      {...props}
+    />
+  )
+);
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(
+  ({ className, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed z-50 grid w-full max-w-lg gap-4 border border-neutral-800 bg-neutral-900 p-6 shadow-lg duration-200 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-md',
+          className
+        )}
+        {...props}
+      />
+    </DialogPortal>
+  )
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />;
+}
+
+const DialogTitle = React.forwardRef<HTMLHeadingElement, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<HTMLParagraphElement, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-neutral-400', className)}
+      {...props}
+    />
+  )
+);
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+  DialogClose,
+};
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "5.15.0",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "2.1.1",
         "next": "14.2.5",
         "next-auth": "^4.24.11",
+        "nuqs": "^2.4.3",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },
@@ -866,6 +868,12 @@
         "@prisma/debug": "5.15.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -881,6 +889,213 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+      "integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
+      "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -889,6 +1104,91 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -947,7 +1247,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -1006,6 +1306,18 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -1291,6 +1603,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1485,6 +1803,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1774,6 +2101,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -1939,6 +2272,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nuqs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.4.3.tgz",
+      "integrity": "sha512-BgtlYpvRwLYiJuWzxt34q2bXu/AIS66sLU1QePIMr2LWkb+XH0vKXdbLSgn9t6p7QKzwI7f38rX3Wl9llTXQ8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mitt": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/franky47"
+      },
+      "peerDependencies": {
+        "@remix-run/react": ">=2",
+        "next": ">=14.2.0",
+        "react": ">=18.2.0 || ^19.0.0-0",
+        "react-router": "^6 || ^7",
+        "react-router-dom": "^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/oauth": {
@@ -2288,6 +2654,75 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -2803,6 +3238,49 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "5.15.0",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
     "next": "14.2.5",
     "next-auth": "^4.24.11",
+    "nuqs": "^2.4.3",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },


### PR DESCRIPTION
## Summary
- replace home page with auth gate redirecting signed-in users to panel
- extract donation form to a client component with URL-persisted fields and YouTube link dialog
- add Radix dialog and nuqs dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4104067c8326b5ca7e7cb807b8fe