### PR TITLE
feat: add streamer donation page

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/db";
+import { DonationForm } from "@/components/donation-form";
+
+interface StreamerPageProps {
+  params: { twitchName: string };
+}
+
+export default async function StreamerPage({ params }: StreamerPageProps) {
+  const { twitchName } = params;
+  const streamer = await prisma.user.findFirst({
+    where: { name: twitchName, accounts: { some: { provider: "twitch" } } },
+    select: { id: true },
+  });
+  if (!streamer) notFound();
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-6 text-2xl font-bold">Підтримати {twitchName}</h1>
+      <Suspense fallback={<div className="card p-6">Завантаження…</div>}>
+        <DonationForm />
+      </Suspense>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add dynamic route for streamer donations
- validate Twitch name via Prisma and 404 if missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a688e8c50832692d6563cb17fd915