### PR TITLE
cache TextToSpeech client

### DIFF
--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,9 +1,18 @@
 import { TextToSpeechClient } from "@google-cloud/text-to-speech";
 export const runtime = "nodejs";
 
-const client = new TextToSpeechClient();
+declare global {
+  // eslint-disable-next-line no-var
+  var ttsClient: TextToSpeechClient | undefined;
+}
+
+function getTtsClient(): TextToSpeechClient {
+  globalThis.ttsClient ??= new TextToSpeechClient();
+  return globalThis.ttsClient;
+}
 
 export async function GET(req: Request) {
+  const client = getTtsClient();
   const { searchParams } = new URL(req.url);
   const text = searchParams.get("text") ?? "";
   const voice = searchParams.get("voice") ?? "uk-UA-Standard-A";


### PR DESCRIPTION
## Summary
- cache Google Cloud TTS client on globalThis to avoid multiple instances during hot reloads
- use cached TTS client in API route before synthesizing speech

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b1e7b7da48326ae9dd3e0b7fc38d7