### PR TITLE
feat(api): validate test donations

### DIFF
--- a/app/api/test/route.ts
+++ b/app/api/test/route.ts
@@ -1,18 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
 import { broadcastDonation, type DonationPayload } from "@/lib/sse";
 
+interface TestDonationBody {
+  nickname: string;
+  message: string;
+  amount: number;
+}
+
+function isValidTestDonationBody(value: unknown): value is TestDonationBody {
+  if (typeof value !== "object" || !value) return false;
+  const body = value as Record<string, unknown>;
+  return (
+    typeof body.nickname === "string" &&
+    typeof body.message === "string" &&
+    typeof body.amount === "number" &&
+    Number.isFinite(body.amount)
+  );
+}
+
 export async function POST(req: NextRequest) {
-  let body: unknown = {};
+  let parsed: unknown;
   try {
-    body = await req.json();
+    parsed = await req.json();
   } catch (err) {
     console.error("Failed to parse test request body", err);
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
+  if (!isValidTestDonationBody(parsed))
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  const { nickname, message, amount } = parsed;
   const payload: DonationPayload = {
     identifier: "TEST-" + Math.random().toString(36).slice(2, 8).toUpperCase(),
-    nickname: (body as any)?.nickname || "kitsune_fan",
-    message: (body as any)?.message || "Це тестове повідомлення",
-    amount: Number((body as any)?.amount) || 50,
+    nickname,
+    message,
+    amount,
     createdAt: new Date().toISOString(),
   };
   broadcastDonation(payload);


### PR DESCRIPTION
## Summary
- add TestDonationBody interface to define expected test request shape
- validate request JSON and respond 400 on invalid input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b50e5609083269efc9029fe0c3c60