### PR TITLE
Remove NextAuth redirect callback and update login flow

### DIFF
--- a/app/login/login-button.tsx
+++ b/app/login/login-button.tsx
@@ -3,7 +3,7 @@ import { signIn } from "next-auth/react";
 
 export function LoginButton() {
   function handleLogin() {
-    signIn("twitch");
+    signIn("twitch", { callbackUrl: "/panel" });
   }
   return (
     <button

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,7 +3,6 @@ import { getServerSession } from "next-auth/next";
 import Credentials from "next-auth/providers/credentials";
 import Twitch from "next-auth/providers/twitch";
 import { prisma } from "./db";
-import { createRedirect } from "./redirect";
 
 export const authOptions = {
   adapter: PrismaAdapter(prisma),
@@ -42,7 +41,6 @@ export const authOptions = {
       if (session.user && user.role) session.user.role = user.role;
       return session;
     },
-    redirect: createRedirect(getAuthSession),
   },
 };
 


### PR DESCRIPTION
## Summary
- drop custom redirect callback from NextAuth auth options
- send Twitch login through `/panel` via callback URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5b2602608326be8280b84cf0a674