### PR TITLE
refactor: use jwt session strategy

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -30,15 +30,25 @@ export const authOptions = {
       },
     }),
   ],
-  session: { strategy: "database" as const },
+  session: { strategy: "jwt" as const },
+  secret: process.env.NEXTAUTH_SECRET,
+  pages: { signIn: "/login" },
   callbacks: {
     async signIn({ user, account }: { user: any; account: any }) {
       if (account?.provider === "twitch") user.role = "streamer";
       if (account?.provider === "credentials") user.role = "admin";
       return true;
     },
-    async session({ session, user }: { session: any; user: any }) {
-      if (session.user && user.role) session.user.role = user.role;
+    async jwt({ token, user }: { token: any; user?: any }) {
+      if (user?.id) token.id = user.id;
+      if (user?.role) token.role = user.role;
+      return token;
+    },
+    async session({ session, token }: { session: any; token: any }) {
+      if (session.user) {
+        if (token.id) session.user.id = token.id as string;
+        if (token.role) session.user.role = token.role as string;
+      }
       return session;
     },
   },


### PR DESCRIPTION
## Summary
- switch NextAuth session strategy to JWT
- persist user `id` and `role` via JWT and session callbacks
- configure secret and custom login page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b66acefb08326afb13bb4fd989974