### PR TITLE
fix(monobank): cache webhook configuration

### DIFF
--- a/app/api/monobank/status/route.ts
+++ b/app/api/monobank/status/route.ts
@@ -10,11 +10,17 @@ interface StatusResponse {
   event: DonationEvent | null;
 }
 
+let configuredWebhookUrl: string | undefined;
+
 export async function GET() {
   try {
     try {
       const webhookUrl = await getSetting("monobankWebhookUrl");
-      if (webhookUrl) await configureWebhook(webhookUrl);
+      if (webhookUrl && configuredWebhookUrl !== webhookUrl) {
+        await configureWebhook(webhookUrl);
+        configuredWebhookUrl = webhookUrl;
+      }
+      if (!webhookUrl) configuredWebhookUrl = undefined;
     } catch (err) {
       console.error("Failed to configure Monobank webhook", err);
     }


### PR DESCRIPTION
## Summary
- avoid redundant Monobank webhook configuration by caching the last configured URL

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b7c64bdcc832683d7d509a613cd5a