### PR TITLE
feat: integrate prisma adapter for next-auth

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,10 +3,13 @@ import Credentials from "next-auth/providers/credentials";
 import Twitch from "next-auth/providers/twitch";
 import type { Account, NextAuthOptions, Session, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import { prisma } from "@/lib/db";
 
 const isProduction = process.env.NODE_ENV === "production";
 
 export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
   providers: [
     Twitch({
       clientId: process.env.TWITCH_CLIENT_ID ?? "",


### PR DESCRIPTION
## Summary
- add Prisma adapter to NextAuth configuration
- wire up Prisma client and keep JWT session strategy

## Testing
- `DATABASE_URL="file:./dev.db" npx prisma migrate deploy`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b973653048326b5a134ca40a7f509