### PR TITLE
Handle Twitch usernames case-insensitively

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -10,7 +10,7 @@ interface StreamerPageProps {
 export default async function StreamerPage({ params }: StreamerPageProps) {
   const { twitchName } = params;
   const streamer = await prisma.user.findFirst({
-    where: { name: twitchName, accounts: { some: { provider: "twitch" } } },
+    where: { name: { equals: twitchName, mode: "insensitive" }, accounts: { some: { provider: "twitch" } } },
     select: { id: true },
   });
   if (!streamer) notFound();


### PR DESCRIPTION
## Summary
- make Twitch username lookups case-insensitive

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b98f1d1d8832684a619fd28ed72d0