### PR TITLE
enforce lowercase usernames

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -9,8 +9,9 @@ interface StreamerPageProps {
 
 export default async function StreamerPage({ params }: StreamerPageProps) {
   const { twitchName } = params;
+  const name = twitchName.toLowerCase();
   const streamer = await prisma.user.findFirst({
-    where: { name: { equals: twitchName, mode: "insensitive" }, accounts: { some: { provider: "twitch" } } },
+    where: { name, accounts: { some: { provider: "twitch" } } },
     select: { id: true },
   });
   if (!streamer) notFound();

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,7 +1,20 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
 export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+function lowercaseUserName(
+  params: Prisma.MiddlewareParams,
+  next: Prisma.MiddlewareNext,
+) {
+  if (params.model === "User" && (params.action === "create" || params.action === "update")) {
+    const name: unknown = params.args.data?.name;
+    if (typeof name === "string") params.args.data.name = name.toLowerCase();
+  }
+  return next(params);
+}
+
+prisma.$use(lowercaseUserName);
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/prisma/migrations/20250812200755_lowercase_user_names/migration.sql
+++ b/prisma/migrations/20250812200755_lowercase_user_names/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "User_name_key" ON "User"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,7 +38,7 @@ model Setting {
 
 model User {
   id            String    @id @default(cuid())
-  name          String?
+  name          String?   @unique
   email         String?   @unique
   emailVerified DateTime?
   image         String?


### PR DESCRIPTION
## Summary
- normalize Twitch usernames to lowercase for lookups
- store user names in lowercase with Prisma middleware
- ensure unique lowercase names via Prisma migration

## Testing
- `DATABASE_URL="file:./prisma/dev.db" npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9e54565883268ede97f79faef738