### PR TITLE
refactor: replace custom button styles with component variants

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,12 +16,6 @@ body {
 .input-base {
   @apply w-full rounded-2xl bg-white/5 px-5 py-3.5 text-neutral-100 placeholder-neutral-400 outline-none ring-1 ring-white/10 transition focus:ring-2 focus:ring-purple-400;
 }
-.btn-primary {
-  @apply inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-6 py-3 font-semibold shadow-lg shadow-fuchsia-900/20 hover:from-violet-400 hover:to-fuchsia-400 disabled:cursor-not-allowed disabled:opacity-50;
-}
-.btn-ghost {
-  @apply inline-flex items-center justify-center rounded-2xl px-5 py-3 font-medium ring-1 ring-white/15 hover:bg-white/5;
-}
 .badge {
   @apply inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs ring-1 ring-white/10;
 }

--- a/app/login/login-button.tsx
+++ b/app/login/login-button.tsx
@@ -1,15 +1,17 @@
 "use client";
 import { signIn } from "next-auth/react";
+import { Button } from "@/components/ui/button";
 
 export function LoginButton() {
   function handleLogin() {
     signIn("twitch", { callbackUrl: "/panel" });
   }
   return (
-    <button
+    <Button
       type="button"
       onClick={handleLogin}
-      className="btn-primary inline-flex items-center gap-2"
+      variant="primary"
+      className="gap-2"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -21,6 +23,6 @@ export function LoginButton() {
         <path d="M13.765 5.882h2.118v5.647h-2.118zm-4.235 0h2.118v5.647H9.53z" />
       </svg>
       Sign in with Twitch
-    </button>
+    </Button>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
+import { Button } from "@/components/ui/button";
 import { authOptions } from "@/lib/auth";
 
 export default async function HomePage() {
@@ -14,17 +15,17 @@ export default async function HomePage() {
       <div className="relative mx-auto max-w-2xl px-6 py-14">
         <div className="card flex flex-col gap-4 p-6 md:p-8">
           {session ? (
-            <Link href="/panel" className="btn-primary text-center">
-              Кабінет
-            </Link>
+            <Button asChild variant="primary">
+              <Link href="/panel">Кабінет</Link>
+            </Button>
           ) : (
             <>
-              <Link href="/login" className="btn-primary text-center">
-                Створити сторінку
-              </Link>
-              <Link href="/panel" className="btn-ghost text-center">
-                Увійти
-              </Link>
+              <Button asChild variant="primary">
+                <Link href="/login">Створити сторінку</Link>
+              </Button>
+              <Button asChild variant="ghost">
+                <Link href="/panel">Увійти</Link>
+              </Button>
             </>
           )}
         </div>

--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -228,23 +228,25 @@ export function DonationForm(_: DonationFormProps) {
       )}
       {error && <p className="text-sm text-rose-400">{error}</p>}
       <div className="grid gap-3 sm:grid-cols-2">
-        <button
+        <Button
           type="submit"
-          className="btn-primary w-full text-lg"
+          variant="primary"
+          className="h-auto w-full text-lg"
           disabled={!isValid || submitting}
           aria-label="Надіслати донат"
         >
           {submitting ? "Готуємо посилання…" : "Надіслати"}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          className="btn-ghost w-full text-lg"
+          variant="ghost"
+          className="h-auto w-full text-lg"
           onClick={handleTest}
           aria-label="Надіслати тест до OBS"
           disabled={testing}
         >
           {testing ? "Тест…" : "Тест сповіщення"}
-        </button>
+        </Button>
       </div>
       <div className="text-center text-xs text-neutral-400">
         Посилання на банку відкриється у новій вкладці без реферера. Після

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,6 +10,9 @@ const buttonVariants = cva(
         default: "bg-brand-500 text-white hover:bg-brand-600",
         outline:
           "border border-neutral-700 bg-transparent hover:bg-neutral-800",
+        primary:
+          "rounded-2xl bg-gradient-to-r from-primary-500 to-secondary-500 font-semibold shadow-lg shadow-secondary-900/20 hover:from-primary-400 hover:to-secondary-400",
+        ghost: "rounded-2xl ring-1 ring-white/15 hover:bg-white/5",
       },
       size: {
         default: "h-9 px-4 py-2",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,11 @@ export default {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
     extend: {
-      colors: { brand: { 500: "#7C4DFF", 600: "#673AB7" } },
+      colors: {
+        brand: { 500: "#7C4DFF", 600: "#673AB7" },
+        primary: { 400: "#A78BFA", 500: "#8B5CF6" },
+        secondary: { 400: "#F0ABFC", 500: "#D946EF" },
+      },
       keyframes: {
         pop: {
           "0%": { transform: "translate(-50%,10px) scale(.96)", opacity: "0" },


### PR DESCRIPTION
## Summary
- replace custom `.btn-*` classes with `Button` component variants
- add `primary` and `ghost` variants and matching Tailwind tokens
- drop legacy button styles from global CSS

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba67d4ebc8326b483caf2093df969