### PR TITLE
feat: add card component for reusable styling

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/db";
 import { DonationForm } from "@/components/donation-form";
+import { Card } from "@/components/ui/card";
 
 interface StreamerPageProps {
   params: { twitchName: string };
@@ -19,7 +20,7 @@ export default async function StreamerPage({ params }: StreamerPageProps) {
   return (
     <main className="mx-auto max-w-2xl p-6">
       <h1 className="mb-6 text-2xl font-bold">Підтримати {twitchName}</h1>
-      <Suspense fallback={<div className="card p-6">Завантаження…</div>}>
+      <Suspense fallback={<Card className="p-6">Завантаження…</Card>}>
         <DonationForm />
       </Suspense>
     </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,9 +10,6 @@ body {
 .title-gradient {
   @apply bg-gradient-to-r from-white via-fuchsia-200 to-purple-300 bg-clip-text text-transparent;
 }
-.card {
-  @apply rounded-3xl bg-white/5 shadow-2xl shadow-purple-900/20 ring-1 ring-white/10 backdrop-blur-xl;
-}
 .input-base {
   @apply w-full rounded-2xl bg-white/5 px-5 py-3.5 text-neutral-100 placeholder-neutral-400 outline-none ring-1 ring-white/10 transition focus:ring-2 focus:ring-purple-400;
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { LoginButton } from "./login-button";
+import { Card } from "@/components/ui/card";
 
 export default function LoginPage() {
   return (
@@ -9,11 +10,11 @@ export default function LoginPage() {
         <div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl" />
       </div>
       <div className="relative mx-auto max-w-2xl px-6 py-14">
-        <div className="card flex justify-center p-6 md:p-8">
+        <Card className="flex justify-center p-6 md:p-8">
           <Suspense fallback={<p>Loading…</p>}>
             <LoginButton />
           </Suspense>
-        </div>
+        </Card>
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { authOptions } from "@/lib/auth";
 
 export default async function HomePage() {
@@ -13,7 +14,7 @@ export default async function HomePage() {
         <div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl" />
       </div>
       <div className="relative mx-auto max-w-2xl px-6 py-14">
-        <div className="card flex flex-col gap-4 p-6 md:p-8">
+        <Card className="flex flex-col gap-4 p-6 md:p-8">
           {session ? (
             <Button asChild variant="primary">
               <Link href="/panel">Кабінет</Link>
@@ -28,7 +29,7 @@ export default async function HomePage() {
               </Button>
             </>
           )}
-        </div>
+        </Card>
       </div>
     </main>
   );

--- a/app/panel/page.tsx
+++ b/app/panel/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { StatusClient, StatusData } from "./status-client";
+import { Card } from "@/components/ui/card";
 
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
@@ -30,13 +31,13 @@ export default async function AdminPage() {
           </h1>
           <div className="badge mt-3">Monobank status</div>
         </header>
-        <div className="card p-6 md:p-8">
+        <Card className="p-6 md:p-8">
           <Suspense
             fallback={<p className="text-center text-neutral-400">Loading…</p>}
           >
             <StatusClient initial={status} />
           </Suspense>
-        </div>
+        </Card>
       </div>
     </main>
   );

--- a/app/panel/settings/page.tsx
+++ b/app/panel/settings/page.tsx
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getSetting, setSetting } from "@/lib/store";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 
 export default async function SettingsPage() {
   const session = await getServerSession(authOptions);
@@ -37,35 +38,37 @@ export default async function SettingsPage() {
           </h1>
           <div className="badge mt-3">Settings</div>
         </header>
-        <form action={save} className="card grid gap-6 p-6 md:p-8">
-          <div className="grid gap-2">
-            <label htmlFor="jarId" className="text-sm text-neutral-300">
-              Jar ID
-            </label>
-            <input
-              id="jarId"
-              name="jarId"
-              defaultValue={jarId ?? ""}
-              className="input-base"
-              required
-            />
-          </div>
-          <div className="grid gap-2">
-            <label htmlFor="monobankToken" className="text-sm text-neutral-300">
-              Monobank token
-            </label>
-            <input
-              id="monobankToken"
-              name="monobankToken"
-              defaultValue={monobankToken ?? ""}
-              className="input-base"
-              required
-            />
-          </div>
-          <Button type="submit" className="w-full">
-            Save
-          </Button>
-        </form>
+        <Card asChild className="grid gap-6 p-6 md:p-8">
+          <form action={save}>
+            <div className="grid gap-2">
+              <label htmlFor="jarId" className="text-sm text-neutral-300">
+                Jar ID
+              </label>
+              <input
+                id="jarId"
+                name="jarId"
+                defaultValue={jarId ?? ""}
+                className="input-base"
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <label htmlFor="monobankToken" className="text-sm text-neutral-300">
+                Monobank token
+              </label>
+              <input
+                id="monobankToken"
+                name="monobankToken"
+                defaultValue={monobankToken ?? ""}
+                className="input-base"
+                required
+              />
+            </div>
+            <Button type="submit" className="w-full">
+              Save
+            </Button>
+          </form>
+        </Card>
       </div>
     </main>
   );

--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
+import { Card } from "@/components/ui/card";
 
 export function DonationForm(_: DonationFormProps) {
   const [nickname, setNickname] = useQueryState(
@@ -111,109 +112,106 @@ export function DonationForm(_: DonationFormProps) {
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="card grid gap-6 p-6 md:p-8"
-      aria-label="Форма донату"
-    >
-      <div>
-        <label className="mb-2 block text-sm text-neutral-300">Сума</label>
-        <div className="flex items-center gap-3">
+    <Card asChild className="grid gap-6 p-6 md:p-8">
+      <form onSubmit={handleSubmit} aria-label="Форма донату">
+        <div>
+          <label className="mb-2 block text-sm text-neutral-300">Сума</label>
+          <div className="flex items-center gap-3">
+            <input
+              type="number"
+              inputMode="numeric"
+              min={10}
+              max={29999}
+              step={1}
+              value={amount}
+              onChange={(e) => setAmount(Number(e.target.value))}
+              className="input-base text-lg"
+              aria-describedby="amount-hint"
+              aria-label="Сума донату"
+              required
+            />
+            <span className="pill flex min-w-[80px] flex-col items-center justify-center text-sm">
+              <span>₴</span>
+              <span className="text-neutral-300">UAH</span>
+            </span>
+          </div>
+          <p id="amount-hint" className="mt-2 text-xs text-neutral-400">
+            Сума від 10 до 29999 ₴
+          </p>
+          {!isAmountValid && (
+            <p className="mt-2 text-xs text-rose-400">
+              Сума має бути від 10 до 29999 ₴
+            </p>
+          )}
+          <div className="mt-3">
+            <AmountPresets value={amount} onChange={setAmount} />
+          </div>
+        </div>
+        <div className="grid gap-2">
+          <label className="text-sm text-neutral-300">Ім&apos;я</label>
           <input
-            type="number"
-            inputMode="numeric"
-            min={10}
-            max={29999}
-            step={1}
-            value={amount}
-            onChange={(e) => setAmount(Number(e.target.value))}
-            className="input-base text-lg"
-            aria-describedby="amount-hint"
-            aria-label="Сума донату"
+            type="text"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            placeholder="ваш нікнейм"
+            className="input-base"
+            aria-label="Нікнейм"
             required
           />
-          <span className="pill flex min-w-[80px] flex-col items-center justify-center text-sm">
-            <span>₴</span>
-            <span className="text-neutral-300">UAH</span>
-          </span>
         </div>
-        <p id="amount-hint" className="mt-2 text-xs text-neutral-400">
-          Сума від 10 до 29999 ₴
-        </p>
-        {!isAmountValid && (
-          <p className="mt-2 text-xs text-rose-400">
-            Сума має бути від 10 до 29999 ₴
-          </p>
-        )}
-        <div className="mt-3">
-          <AmountPresets value={amount} onChange={setAmount} />
+        <div className="grid gap-2">
+          <label className="text-sm text-neutral-300">Повідомлення</label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="ваше повідомлення (макс. 500 символів)"
+            className="input-base min-h-[120px] resize-y"
+            maxLength={500}
+            aria-label="Повідомлення"
+            required
+          />
+          <p className="text-xs text-neutral-500">Максимум символів – 500</p>
         </div>
-      </div>
-      <div className="grid gap-2">
-        <label className="text-sm text-neutral-300">Ім&apos;я</label>
-        <input
-          type="text"
-          value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
-          placeholder="ваш нікнейм"
-          className="input-base"
-          aria-label="Нікнейм"
-          required
-        />
-      </div>
-      <div className="grid gap-2">
-        <label className="text-sm text-neutral-300">Повідомлення</label>
-        <textarea
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="ваше повідомлення (макс. 500 символів)"
-          className="input-base min-h-[120px] resize-y"
-          maxLength={500}
-          aria-label="Повідомлення"
-          required
-        />
-        <p className="text-xs text-neutral-500">Максимум символів – 500</p>
-      </div>
-      <div className="flex gap-3">
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-          <DialogTrigger asChild>
-            <Button type="button" variant="outline">
-              YouTube
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>Посилання на YouTube</DialogTitle>
-            </DialogHeader>
-            <input
-              className="input-base mt-4 w-full"
-              placeholder="https://youtu.be/..."
-              value={youtubeInput}
-              onChange={(e) => setYoutubeInput(e.target.value)}
-            />
-            {embed && (
-              <div className="mt-4 aspect-video">
-                <iframe
-                  src={embed}
-                  className="h-full w-full rounded-md"
-                  loading="lazy"
-                  title="Попередній перегляд YouTube відео"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowFullScreen
-                />
-              </div>
-            )}
-            <DialogFooter className="mt-4 gap-2">
-              <Button type="button" onClick={handleAttach} disabled={!embed}>
-                Прикріпити
+        <div className="flex gap-3">
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button type="button" variant="outline">
+                YouTube
               </Button>
-              <Button type="button" variant="outline" onClick={handleClear}>
-                Очистити
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </div>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Посилання на YouTube</DialogTitle>
+              </DialogHeader>
+              <input
+                className="input-base mt-4 w-full"
+                placeholder="https://youtu.be/..."
+                value={youtubeInput}
+                onChange={(e) => setYoutubeInput(e.target.value)}
+              />
+              {embed && (
+                <div className="mt-4 aspect-video">
+                  <iframe
+                    src={embed}
+                    className="h-full w-full rounded-md"
+                    loading="lazy"
+                    title="Попередній перегляд YouTube відео"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  />
+                </div>
+              )}
+              <DialogFooter className="mt-4 gap-2">
+                <Button type="button" onClick={handleAttach} disabled={!embed}>
+                  Прикріпити
+                </Button>
+                <Button type="button" variant="outline" onClick={handleClear}>
+                  Очистити
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
       {youtube && (
         <div className="aspect-video">
           <iframe
@@ -259,7 +257,8 @@ export function DonationForm(_: DonationFormProps) {
           </div>
         </div>
       )}
-    </form>
+      </form>
+    </Card>
   );
 }
 

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { clsx } from "clsx";
+
+function cn(...classes: unknown[]): string {
+  return clsx(classes);
+}
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean;
+}
+
+function Card({ className, asChild, ...props }: CardProps) {
+  const Comp = asChild ? Slot : "div";
+  return (
+    <Comp
+      className={cn(
+        "rounded-3xl bg-white/5 shadow-2xl shadow-purple-900/20 ring-1 ring-white/10 backdrop-blur-xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mb-4", className)} {...props} />;
+}
+
+function CardFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mt-4", className)} {...props} />;
+}
+
+export { Card, CardHeader, CardFooter };


### PR DESCRIPTION
## Summary
- add reusable Card component with optional header and footer slots
- replace global `.card` class and update pages to use `<Card>`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bac6b68588326aae9e6c91d95e974