### PR TITLE
feat: add global Inter font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
 import "./globals.css";
+import { Inter } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
@@ -7,7 +10,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <head>
         <meta name="referrer" content="no-referrer" />
       </head>
-      <body>
+      <body className={`${inter.variable} font-sans`}>
         <NuqsAdapter>{children}</NuqsAdapter>
       </body>
     </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "tailwindcss";
 export default {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
+    fontFamily: { sans: ["var(--font-inter)"] },
     extend: {
       colors: {
         brand: { 500: "#7C4DFF", 600: "#673AB7" },


### PR DESCRIPTION
## Summary
- integrate Inter from next/font/google and apply it to the body
- configure Tailwind to use the Inter variable font and remove browser fallbacks

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689bb6e646f08326b3f5e8eae4368bf7