### PR TITLE
feat: refine admin user table

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,54 +1,112 @@
+import { Suspense } from "react";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/db";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { RoleSelect } from "./role-select";
 
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== "admin") redirect("/admin/login");
 
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+      <Suspense fallback={<TableSkeleton />}>
+        <UserTable />
+      </Suspense>
+    </main>
+  );
+}
+
+async function UserTable() {
   const users = await prisma.user.findMany({
     where: { accounts: { some: { provider: "twitch" } } },
     select: { id: true, name: true, email: true, role: true },
   });
 
   return (
-    <main className="mx-auto max-w-2xl p-6">
-      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
-      <UserTable users={users} />
-    </main>
-  );
-}
-
-function UserTable({ users }: { users: User[] }) {
-  return (
-    <table className="mt-6 w-full text-sm">
-      <thead className="text-left">
-        <tr>
-          <th className="pb-2">Name</th>
-          <th className="pb-2">Email</th>
-          <th className="pb-2">Role</th>
-        </tr>
-      </thead>
-      <tbody className="divide-y divide-neutral-700">
+    <Table className="mt-6">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {users.map((user) => (
-          <tr key={user.id} className="h-10">
-            <td className="pr-4">{user.name}</td>
-            <td className="pr-4">{user.email}</td>
-            <td>
+          <TableRow
+            key={user.id}
+            className="odd:bg-neutral-900 even:bg-neutral-800 hover:bg-neutral-700"
+          >
+            <TableCell className="pr-4">{user.name}</TableCell>
+            <TableCell className="pr-4">{user.email}</TableCell>
+            <TableCell className="flex items-center gap-2">
+              <RoleBadge role={user.role} />
               <RoleSelect userId={user.id} initialRole={user.role} />
-            </td>
-          </tr>
+            </TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   );
 }
 
-interface User {
-  id: string;
-  name: string | null;
-  email: string | null;
+function TableSkeleton() {
+  return (
+    <Table className="mt-6" aria-busy="true">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {[0, 1, 2].map((i) => (
+          <TableRow
+            key={i}
+            data-state="loading"
+            className="odd:bg-neutral-900 even:bg-neutral-800"
+          >
+            <TableCell className="pr-4">
+              <div className="h-4 w-24 rounded bg-neutral-700" />
+            </TableCell>
+            <TableCell className="pr-4">
+              <div className="h-4 w-32 rounded bg-neutral-700" />
+            </TableCell>
+            <TableCell>
+              <div className="h-4 w-16 rounded bg-neutral-700" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function RoleBadge({ role }: RoleBadgeProps) {
+  const variants: Record<string, string> = {
+    admin: "bg-brand-500 text-white",
+    streamer: "bg-neutral-700 text-neutral-200",
+  };
+  return (
+    <Badge className={variants[role] || "bg-neutral-700 text-neutral-200"}>
+      {role}
+    </Badge>
+  );
+}
+
+interface RoleBadgeProps {
   role: string;
 }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { clsx } from "clsx";
+import { cva, type VariantProps } from "class-variance-authority";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold", 
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-neutral-800 text-neutral-200",
+        secondary: "border-transparent bg-neutral-700 text-neutral-200",
+        outline: "border-neutral-700 text-neutral-200",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+);
+
+function cn(...classes: unknown[]): string {
+  return clsx(classes);
+}
+
+interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { badgeVariants };

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { clsx } from "clsx";
+
+function cn(...classes: unknown[]): string {
+  return clsx(classes);
+}
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-neutral-300",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b border-neutral-700 transition-colors hover:bg-neutral-800 data-[state=loading]:animate-pulse",
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn("px-2 align-middle", className)} {...props} />
+));
+TableCell.displayName = "TableCell";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+};


### PR DESCRIPTION
## Summary
- replace raw table with Shadcn UI Table primitives
- show badges for user roles and add loading skeleton
- create reusable Table and Badge components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb839d6408326843616f08b56b9be