### PR TITLE
feat: integrate radix toast for donation feedback

### DIFF
--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -13,6 +13,13 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Card } from "@/components/ui/card";
+import {
+  ToastProvider,
+  Toast,
+  ToastTitle,
+  ToastClose,
+  ToastViewport,
+} from "@/components/ui/toast";
 
 export function DonationForm(_: DonationFormProps) {
   const [nickname, setNickname] = useQueryState(
@@ -33,7 +40,8 @@ export function DonationForm(_: DonationFormProps) {
   const [submitting, setSubmitting] = useState(false);
   const [testing, setTesting] = useState(false);
   const [error, setError] = useState("");
-  const [toast, setToast] = useState("");
+  const [toastOpen, setToastOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
 
   const isAmountValid = amount >= 10 && amount <= 29999;
   const isValid = useMemo(() => {
@@ -44,8 +52,8 @@ export function DonationForm(_: DonationFormProps) {
   }, [nickname, amount, message, isAmountValid]);
 
   function showToast(text: string) {
-    setToast(text);
-    setTimeout(() => setToast(""), 3000);
+    setToastMessage(text);
+    setToastOpen(true);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -112,11 +120,12 @@ export function DonationForm(_: DonationFormProps) {
   }
 
   return (
-    <Card
-      asChild
-      className="grid gap-6 px-4 py-5 sm:px-6 sm:py-6 md:px-8 md:py-8 lg:px-10 lg:py-10"
-    >
-      <form onSubmit={handleSubmit} aria-label="Форма донату">
+    <ToastProvider duration={3000}>
+      <Card
+        asChild
+        className="grid gap-6 px-4 py-5 sm:px-6 sm:py-6 md:px-8 md:py-8 lg:px-10 lg:py-10"
+      >
+        <form onSubmit={handleSubmit} aria-label="Форма донату">
         <div>
           <label className="mb-2 block text-sm text-neutral-300">Сума</label>
           <div className="flex items-center gap-3">
@@ -253,17 +262,14 @@ export function DonationForm(_: DonationFormProps) {
         Посилання на банку відкриється у новій вкладці без реферера. Після
         донату ваш нік, сума і повідомлення з’являться в OBS.
       </div>
-      {toast && (
-        <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2">
-          <div
-            className="rounded-full bg-white/10 px-3 py-2 text-sm shadow-lg ring-1 ring-white/20 sm:px-4 sm:py-2 md:px-6 md:py-3 lg:px-8 lg:py-4"
-          >
-            {toast}
-          </div>
-        </div>
-      )}
-      </form>
-    </Card>
+        </form>
+      </Card>
+      <Toast open={toastOpen} onOpenChange={setToastOpen}>
+        <ToastTitle>{toastMessage}</ToastTitle>
+        <ToastClose />
+      </Toast>
+      <ToastViewport />
+    </ToastProvider>
   );
 }
 

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import * as ToastPrimitive from "@radix-ui/react-toast";
+import { clsx } from "clsx";
+
+function cn(...classes: unknown[]): string {
+  return clsx(classes);
+}
+
+const ToastProvider = ToastPrimitive.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Viewport
+    ref={ref}
+    className={cn(
+      "fixed bottom-6 left-1/2 z-50 flex w-full max-w-xs -translate-x-1/2 flex-col-reverse gap-2 p-4",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitive.Viewport.displayName;
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Root
+    ref={ref}
+    className={cn(
+      "group relative grid w-full items-center justify-between rounded-full bg-white/10 px-3 py-2 text-sm shadow-lg ring-1 ring-white/20 sm:px-4 sm:py-2 md:px-6 md:py-3 lg:px-8 lg:py-4",
+      className,
+    )}
+    {...props}
+  />
+));
+Toast.displayName = ToastPrimitive.Root.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Title ref={ref} className={cn(className)} {...props} />
+));
+ToastTitle.displayName = ToastPrimitive.Title.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitive.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitive.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitive.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-white/60 transition hover:text-white focus:outline-none focus:ring-1 focus:ring-white/20",
+      className,
+    )}
+    aria-label="Close"
+    {...props}
+  >
+    <span aria-hidden>×</span>
+  </ToastPrimitive.Close>
+));
+ToastClose.displayName = ToastPrimitive.Close.displayName;
+
+export { ToastProvider, ToastViewport, Toast, ToastTitle, ToastClose };
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@prisma/client": "5.15.0",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-toast": "^1.2.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "2.1.1",
         "next": "14.2.5",
@@ -1263,6 +1264,32 @@
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1503,6 +1530,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.14.tgz",
+      "integrity": "sha512-nAP5FBxBJGQ/YfUB+r+O6USFVkWq3gAInkxyEnmvEV5jtSbfDhfa4hwX8CraCnbjMLsE7XSf/K75l9xXY7joWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -1584,6 +1645,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@prisma/client": "5.15.0",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toast": "^1.2.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
     "next": "14.2.5",


### PR DESCRIPTION
## Summary
- implement Radix-based toast component with shadcn styling
- replace manual toast logic in donation form with Radix Toast provider
- add @radix-ui/react-toast dependency

## Testing
- `npm test` (fails: monobank-webhook-config.test.ts)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689bba7a2b448326904e7c61eb844003