### PR TITLE
style: polish admin login

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -4,39 +4,49 @@ import { Button } from "@/components/ui/button";
 export default async function AdminLoginPage() {
   const csrfToken = await getCsrfToken();
   return (
-    <main className="mx-auto max-w-sm p-6">
-      <form
-        method="post"
-        action="/api/auth/callback/credentials"
-        className="flex flex-col gap-4"
-      >
-        <input
-          name="csrfToken"
-          type="hidden"
-          defaultValue={csrfToken ?? undefined}
-        />
-        <label className="flex flex-col gap-1">
-          <span className="text-sm text-neutral-300">Login</span>
-          <input
-            name="login"
-            className="rounded-md border border-neutral-700 bg-transparent p-2"
-            required
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-sm text-neutral-300">Password</span>
-          <input
-            name="password"
-            type="password"
-            className="rounded-md border border-neutral-700 bg-transparent p-2"
-            required
-          />
-        </label>
-        <input type="hidden" name="callbackUrl" value="/admin" />
-        <Button type="submit" className="w-full">
-          Sign in
-        </Button>
-      </form>
+    <main className="relative min-h-screen overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-40 -top-40 h-[36rem] w-[36rem] rounded-full bg-fuchsia-600/20 blur-3xl" />
+        <div className="absolute -bottom-40 -right-40 h-[36rem] w-[36rem] rounded-full bg-violet-600/20 blur-3xl" />
+      </div>
+      <div className="relative mx-auto max-w-sm px-6 py-14">
+        <header className="mb-8 text-center">
+          <h1 className="title-gradient text-4xl font-extrabold drop-shadow-sm md:text-5xl">
+            Admin
+          </h1>
+          <div className="badge mt-3">Вхід до панелі</div>
+        </header>
+        <div className="card p-6 md:p-8">
+          <form
+            method="post"
+            action="/api/auth/callback/credentials"
+            className="flex flex-col gap-4"
+          >
+            <input
+              name="csrfToken"
+              type="hidden"
+              defaultValue={csrfToken ?? undefined}
+            />
+            <label className="flex flex-col gap-1">
+              <span className="text-sm text-neutral-300">Login</span>
+              <input name="login" className="input-base" required />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-sm text-neutral-300">Password</span>
+              <input
+                name="password"
+                type="password"
+                className="input-base"
+                required
+              />
+            </label>
+            <input type="hidden" name="callbackUrl" value="/admin" />
+            <Button type="submit" className="w-full">
+              Sign in
+            </Button>
+          </form>
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- wrap admin login in full-screen layout with background gradients
- add header and card-styled login form
- style inputs with `input-base` and full-width button

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689bc64d018c832697793f939734608c