### PR TITLE
Align YouTube dialog trigger button styling

### DIFF
--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -181,7 +181,11 @@ export function DonationForm(_: DonationFormProps) {
       <div className="flex gap-2">
         <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
           <DialogTrigger asChild>
-            <Button type="button" variant="outline">
+            <Button
+              type="button"
+              variant="default"
+              className="w-full text-lg"
+            >
               YouTube
             </Button>
           </DialogTrigger>


### PR DESCRIPTION
## Summary
- use default variant and full-width large text styling for YouTube dialog button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c83e4573c83269367bd48b45de2d5