### PR TITLE
feat: add auth navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import "./globals.css";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Suspense } from "react";
+import { NavAuth } from "@/components/nav-auth";
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
@@ -9,6 +11,11 @@ export default function RootLayout({ children }: RootLayoutProps) {
       </head>
       <body>
         <NuqsAdapter>{children}</NuqsAdapter>
+        <div className="fixed right-4 top-4">
+          <Suspense fallback={null}>
+            <NavAuth />
+          </Suspense>
+        </div>
       </body>
     </html>
   );

--- a/components/nav-auth.tsx
+++ b/components/nav-auth.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function NavAuth(_: NavAuthProps) {
+  const { data: session } = useSession();
+
+  if (!session?.user)
+    return (
+      <div className="flex gap-2">
+        <Button asChild variant="outline">
+          <Link href="/register">Зареєструватись</Link>
+        </Button>
+        <Button asChild>
+          <Link href="/login">Увійти</Link>
+        </Button>
+      </div>
+    );
+
+  return (
+    <div>
+      <Button asChild>
+        <Link href="/panel">Кабінет</Link>
+      </Button>
+    </div>
+  );
+}
+
+interface NavAuthProps {}
+


### PR DESCRIPTION
## Summary
- add navigation auth widget with session-aware links
- render auth buttons in top-right of layout

## Testing
- `npm test` (fails: TypeError import_client.PrismaClient is not a constructor)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c877615b48326960daa0034eb0d64