### PR TITLE
Fix message textarea spacing

### DIFF
--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -133,7 +133,7 @@ export function DonationForm(_: DonationFormProps) {
           required
         />
       </div>
-      <div className="grid gap-1">
+      <div className="grid gap-2">
         <label className="text-sm text-neutral-300">Повідомлення</label>
         <textarea
           value={message}


### PR DESCRIPTION
## Summary
- adjust message textarea container gap to avoid extra space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c877d5730832690fa638fe033ecd4