### PR TITLE
Prefill donation nickname from session

### DIFF
--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { useQueryState, parseAsInteger, parseAsString } from "nuqs";
+import { useSession } from "next-auth/react";
 import { AmountPresets } from "./amount-presets";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,6 +32,16 @@ export function DonationForm(_: DonationFormProps) {
   const [youtube, setYoutube] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const { data: session } = useSession();
+  const filledRef = useRef(false);
+
+  useEffect(() => {
+    if (filledRef.current) return;
+    if (session?.user?.name && !nickname) {
+      setNickname(session.user.name);
+      filledRef.current = true;
+    }
+  }, [session?.user?.name, nickname, setNickname]);
 
   const isAmountValid = amount >= 10 && amount <= 29999;
   const isValid = useMemo(() => {


### PR DESCRIPTION
## Summary
- auto-fill donation nickname from authenticated session when empty
- ensure nickname field stays editable by avoiding repeated autofill

## Testing
- `npm test` (fails: appendIntent handles concurrent writes)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c877bbca88326b94c4b71355e1562