### PR TITLE
refactor: centralize auth and nuqs providers

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 import { Suspense } from "react";
-import { SessionProvider } from "next-auth/react";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Providers } from "@/components/providers";
 import { NavAuth } from "@/components/nav-auth";
 import { getAuthSession } from "@/lib/auth";
 
@@ -14,14 +13,14 @@ export default async function RootLayout({ children }: RootLayoutProps) {
         <meta name="referrer" content="no-referrer" />
       </head>
       <body>
-        <SessionProvider session={session}>
-          <NuqsAdapter>{children}</NuqsAdapter>
+        <Providers session={session}>
+          {children}
           <div className="fixed right-4 top-4">
             <Suspense fallback={null}>
               <NavAuth />
             </Suspense>
           </div>
-        </SessionProvider>
+        </Providers>
       </body>
     </html>
   );

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import type { Session } from "next-auth";
+
+export function Providers({ session, children }: ProvidersProps) {
+  return (
+    <SessionProvider session={session}>
+      <NuqsAdapter>{children}</NuqsAdapter>
+    </SessionProvider>
+  );
+}
+
+interface ProvidersProps {
+  session: Session | null;
+  children: React.ReactNode;
+}
+


### PR DESCRIPTION
## Summary
- add Providers component bundling SessionProvider and NuqsAdapter
- use Providers in root layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8ec469b88326af55c84d476c4d3a