### PR TITLE
refactor: centralize auth session retrieval

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,11 +1,10 @@
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { authOptions } from "@/lib/auth";
+import { getAuthSession } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { RoleSelect } from "./role-select";
 
 export default async function AdminPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getAuthSession();
   if (!session || session.user.role !== "admin") redirect("/admin/login");
 
   const users = await prisma.user.findMany({

--- a/app/api/users/[id]/role/route.ts
+++ b/app/api/users/[id]/role/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getAuthSession } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 
 interface RoleBody {
@@ -11,7 +10,7 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getAuthSession();
   if (!session || session.user.role !== "admin")
     return new NextResponse("Unauthorized", { status: 401 });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,8 @@
 import Link from "next/link";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getAuthSession } from "@/lib/auth";
 
 export default async function HomePage() {
-  const session = await getServerSession(authOptions);
+  const session = await getAuthSession();
 
   return (
     <main className="relative min-h-screen overflow-hidden">

--- a/app/panel/page.tsx
+++ b/app/panel/page.tsx
@@ -1,12 +1,11 @@
 import { Suspense } from "react";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getAuthSession } from "@/lib/auth";
 import { StatusClient, StatusData } from "./status-client";
 
 export default async function AdminPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getAuthSession();
   if (!session || session.user?.role !== "streamer") redirect("/login");
 
   const h = headers();

--- a/app/panel/settings/page.tsx
+++ b/app/panel/settings/page.tsx
@@ -1,11 +1,10 @@
 import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getAuthSession } from "@/lib/auth";
 import { getSetting, setSetting } from "@/lib/store";
 import { Button } from "@/components/ui/button";
 
 export default async function SettingsPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getAuthSession();
   if (!session || session.user?.role !== "admin") redirect("/login");
 
   const [jarId, monobankToken] = await Promise.all([


### PR DESCRIPTION
## Summary
- replace direct `getServerSession(authOptions)` calls with `getAuthSession`
- drop unused `authOptions` imports

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c91bcab088326b9c8fedac04c3b1f