### PR TITLE
Prefill nickname from session

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/db";
 import { DonationForm } from "@/components/donation-form";
+import { getAuthSession } from "@/lib/auth";
 
 interface StreamerPageProps {
   params: { twitchName: string };
@@ -15,6 +16,7 @@ export default async function StreamerPage({ params }: StreamerPageProps) {
     select: { id: true },
   });
   if (!streamer) notFound();
+  const session = await getAuthSession();
 
   return (
     <main className="relative min-h-screen overflow-hidden">
@@ -30,7 +32,7 @@ export default async function StreamerPage({ params }: StreamerPageProps) {
           <div className="badge mt-3">Донат через Monobank 💖</div>
         </header>
         <Suspense fallback={<div className="card p-6 md:p-8">Завантаження…</div>}>
-          <DonationForm />
+          <DonationForm initialName={session?.user?.name} />
         </Suspense>
       </div>
     </main>

--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useMemo, useRef, useState, useEffect } from "react";
+import { useMemo, useState } from "react";
 import { useQueryState, parseAsInteger, parseAsString } from "nuqs";
-import { useSession } from "next-auth/react";
 import { AmountPresets } from "./amount-presets";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,10 +13,10 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 
-export function DonationForm(_: DonationFormProps) {
+export function DonationForm({ initialName = "" }: DonationFormProps) {
   const [nickname, setNickname] = useQueryState(
     "nickname",
-    parseAsString.withDefault(""),
+    parseAsString.withDefault(initialName),
   );
   const [amount, setAmount] = useQueryState(
     "amount",
@@ -32,16 +31,6 @@ export function DonationForm(_: DonationFormProps) {
   const [youtube, setYoutube] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
-  const { data: session } = useSession();
-  const filledRef = useRef(false);
-
-  useEffect(() => {
-    if (filledRef.current) return;
-    if (session?.user?.name && !nickname) {
-      setNickname(session.user.name);
-      filledRef.current = true;
-    }
-  }, [session?.user?.name, nickname, setNickname]);
 
   const isAmountValid = amount >= 10 && amount <= 29999;
   const isValid = useMemo(() => {
@@ -251,4 +240,6 @@ function extractYoutubeId(url: string): string | null {
   }
 }
 
-interface DonationFormProps {}
+interface DonationFormProps {
+  initialName?: string;
+}


### PR DESCRIPTION
## Summary
- Pass session username to `DonationForm` from server page
- Use `parseAsString.withDefault` to set initial nickname
- Remove client-side session effect and ref

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c92d7a8d88326b41283b6c7165ddb