### PR TITLE
fix underscore color in twitch name title

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -27,7 +27,7 @@ export default async function StreamerPage({ params }: StreamerPageProps) {
       <div className="relative mx-auto max-w-2xl px-6 py-14">
         <header className="mb-8 text-center">
           <h1 className="title-gradient text-4xl font-extrabold drop-shadow-sm md:text-5xl">
-            Підтримати {twitchName}
+            Підтримати <span className="text-neutral-100">{twitchName}</span>
           </h1>
           <div className="badge mt-3">Донат через Monobank 💖</div>
         </header>

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@ body {
   @apply bg-neutral-950 text-neutral-100 antialiased;
 }
 .title-gradient {
-  @apply bg-gradient-to-r from-white via-fuchsia-200 to-purple-300 bg-clip-text text-transparent;
+  @apply bg-gradient-to-r from-white via-fuchsia-200 to-purple-300 bg-clip-text text-transparent text-neutral-100 [background-size:100%_100%];
 }
 .card {
   @apply rounded-3xl bg-white/5 shadow-2xl shadow-purple-900/20 ring-1 ring-white/10 backdrop-blur-xl;


### PR DESCRIPTION
## Summary
- wrap `twitchName` in a neutral span so underscores inherit the text color
- adjust title gradient to cover full line height and include a fallback tint

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ca011f1c4832682a6c252518874df