### PR TITLE
fix title gradient for Twitch names

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -27,11 +27,13 @@ export default async function StreamerPage({ params }: StreamerPageProps) {
       <div className="relative mx-auto max-w-2xl px-6 py-14">
         <header className="mb-8 text-center">
           <h1 className="title-gradient text-4xl font-extrabold drop-shadow-sm md:text-5xl">
-            Підтримати <span className="text-neutral-100">{twitchName}</span>
+            Підтримати {twitchName}
           </h1>
           <div className="badge mt-3">Донат через Monobank 💖</div>
         </header>
-        <Suspense fallback={<div className="card p-6 md:p-8">Завантаження…</div>}>
+        <Suspense
+          fallback={<div className="card p-6 md:p-8">Завантаження…</div>}
+        >
           <DonationForm initialName={session?.user?.name} />
         </Suspense>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@ body {
   @apply bg-neutral-950 text-neutral-100 antialiased;
 }
 .title-gradient {
-  @apply bg-gradient-to-r from-white via-fuchsia-200 to-purple-300 bg-clip-text text-transparent text-neutral-100 [background-size:100%_100%];
+  @apply bg-gradient-to-r from-white via-fuchsia-200 to-purple-300 bg-clip-text text-transparent [background-size:100%_100%];
 }
 .card {
   @apply rounded-3xl bg-white/5 shadow-2xl shadow-purple-900/20 ring-1 ring-white/10 backdrop-blur-xl;


### PR DESCRIPTION
## Summary
- remove text color override from title-gradient utility to ensure gradients display
- apply title gradient directly to Twitch usernames

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Property 'user' does not exist on type '{}')*

------
https://chatgpt.com/codex/tasks/task_e_689ca66192488326b758ef727b899442