### PR TITLE
fix: render underscores with gradient

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@ body {
   @apply bg-neutral-950 text-neutral-100 antialiased;
 }
 .title-gradient {
-  @apply bg-gradient-to-r from-white via-fuchsia-200 to-purple-300 bg-clip-text text-transparent [background-size:100%_100%];
+  @apply inline-block whitespace-pre bg-gradient-to-r from-white via-fuchsia-200 to-purple-300 bg-clip-text text-transparent [background-size:100%_100%];
 }
 .card {
   @apply rounded-3xl bg-white/5 shadow-2xl shadow-purple-900/20 ring-1 ring-white/10 backdrop-blur-xl;


### PR DESCRIPTION
## Summary
- ensure underscores are visible inside gradient titles

## Testing
- `npm test`
- `npm run lint`
- `curl -I http://localhost:3000/kitsune_voice` *(fails: PrismaClientInitializationError: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689cb9916bd48326adaf3df0e07ca59c