### PR TITLE
Align amount hint with preset buttons

### DIFF
--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -108,7 +108,10 @@ export function DonationForm({ initialName = "" }: DonationFormProps) {
             <span className="text-neutral-300">UAH</span>
           </span>
         </div>
-        <p id="amount-hint" className="mt-1 text-xs text-neutral-400">
+        <p
+          id="amount-hint"
+          className="mt-1 pr-[calc(80px+2rem+0.5rem)] text-right text-xs text-neutral-400"
+        >
           Сума від 10 до 29999 ₴
         </p>
         {!isAmountValid && (


### PR DESCRIPTION
## Summary
- align amount helper text with preset buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb9991d048326a6dc23e6c7b6ebdd