### PR TITLE
feat: add gradient helpers and apply to buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,6 +19,19 @@ body {
 .btn-primary {
   @apply inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-6 py-3 font-semibold shadow-lg shadow-fuchsia-900/20 hover:from-violet-400 hover:to-fuchsia-400 disabled:cursor-not-allowed disabled:opacity-50;
 }
+.text-gradient {
+  @apply bg-gradient-to-r from-violet-500 to-fuchsia-500 bg-clip-text text-transparent;
+}
+.text-gradient-underline {
+  @apply relative inline-block bg-gradient-to-r from-violet-500 to-fuchsia-500 bg-clip-text text-transparent;
+}
+.text-gradient-underline::after {
+  content: "";
+  @apply absolute left-0 bottom-0 h-px w-full bg-gradient-to-r from-violet-500 to-fuchsia-500;
+}
+.btn-secondary {
+  @apply inline-flex items-center justify-center rounded-2xl px-6 py-3 font-semibold ring-1 ring-white/15 hover:bg-white/5 bg-gradient-to-r from-violet-500 to-fuchsia-500 bg-clip-text text-transparent disabled:cursor-not-allowed disabled:opacity-50;
+}
 .btn-ghost {
   @apply inline-flex items-center justify-center rounded-2xl px-5 py-3 font-medium ring-1 ring-white/15 hover:bg-white/5;
 }

--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState } from "react";
 import { useQueryState, parseAsInteger, parseAsString } from "nuqs";
 import { AmountPresets } from "./amount-presets";
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogTrigger,
@@ -205,12 +204,21 @@ export function DonationForm({ initialName = "" }: DonationFormProps) {
               </div>
             )}
             <DialogFooter className="mt-3 gap-1">
-              <Button type="button" onClick={handleAttach} disabled={!embed}>
+              <button
+                type="button"
+                onClick={handleAttach}
+                disabled={!embed}
+                className="btn-primary"
+              >
                 Прикріпити
-              </Button>
-              <Button type="button" variant="outline" onClick={handleClear}>
+              </button>
+              <button
+                type="button"
+                onClick={handleClear}
+                className="btn-secondary"
+              >
                 Очистити
-              </Button>
+              </button>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/components/nav-auth.tsx
+++ b/components/nav-auth.tsx
@@ -2,28 +2,26 @@
 
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-
 export function NavAuth() {
   const { data: session } = useSession();
 
   if (!session?.user)
     return (
       <div className="flex gap-2">
-        <Button asChild variant="outline">
-          <Link href="/register">Зареєструватись</Link>
-        </Button>
-        <Button asChild>
-          <Link href="/login">Увійти</Link>
-        </Button>
+        <Link href="/register" className="btn-secondary">
+          Зареєструватись
+        </Link>
+        <Link href="/login" className="btn-primary">
+          Увійти
+        </Link>
       </div>
     );
 
   return (
     <div>
-      <Button asChild>
-        <Link href="/panel">Кабінет</Link>
-      </Button>
+      <Link href="/panel" className="btn-primary">
+        Кабінет
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add gradient text/underline helpers and secondary button style
- use gradient-based buttons in auth nav and donation form

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb9b8a1948326951ff883e48d9afc