### PR TITLE
style: apply card design to dialog content

### DIFF
--- a/components/donation-form.tsx
+++ b/components/donation-form.tsx
@@ -182,7 +182,7 @@ export function DonationForm({ initialName = "" }: DonationFormProps) {
               </svg>
             </button>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-md">
+          <DialogContent className="sm:max-w-md card">
             <DialogHeader>
               <DialogTitle>Посилання на YouTube</DialogTitle>
             </DialogHeader>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-md border border-neutral-800 bg-neutral-900 p-6 shadow-lg duration-200",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-3xl bg-white/5 p-6 ring-1 ring-white/10 backdrop-blur-xl shadow-2xl shadow-purple-900/20 duration-200",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- update DialogContent to use global card styles
- apply `card` class in DonationForm DialogContent usage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb9a359f483269a185c220409635d