### PR TITLE
refactor: replace nav auth buttons

### DIFF
--- a/components/nav-auth.tsx
+++ b/components/nav-auth.tsx
@@ -2,7 +2,6 @@
 
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
 
 export function NavAuth() {
   const { data: session } = useSession();
@@ -10,20 +9,20 @@ export function NavAuth() {
   if (!session?.user)
     return (
       <div className="flex gap-2">
-        <Button asChild variant="outline">
-          <Link href="/register">Зареєструватись</Link>
-        </Button>
-        <Button asChild>
-          <Link href="/login">Увійти</Link>
-        </Button>
+        <Link href="/register" className="inline-block">
+          <button className="btn btn-ghost">Зареєструватись</button>
+        </Link>
+        <Link href="/login" className="inline-block">
+          <button className="btn btn-primary">Увійти</button>
+        </Link>
       </div>
     );
 
   return (
     <div>
-      <Button asChild>
-        <Link href="/panel">Кабінет</Link>
-      </Button>
+      <Link href="/panel" className="inline-block">
+        <button className="btn btn-primary">Кабінет</button>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace shadcn Button with standard button in nav auth
- apply btn-primary and btn-ghost classes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb9aa714083269db7dba38371440d