### PR TITLE
feat: equal width amount preset buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -42,6 +42,10 @@ body {
   @apply rounded-2xl bg-white/5 px-4 py-2 ring-1 ring-white/10 transition hover:bg-white/10;
 }
 
+.pill-amount {
+  @apply pill w-20;
+}
+
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;

--- a/components/amount-presets.tsx
+++ b/components/amount-presets.tsx
@@ -4,13 +4,16 @@ import { clsx } from "clsx";
 
 export function AmountPresets({ value, onChange }: AmountPresetsProps) {
   return (
-    <div className="flex flex-wrap gap-3">
+    <div className="grid grid-cols-4 gap-3">
       {presets.map((preset) => (
         <button
           key={preset}
           type="button"
           aria-label={`Обрати ${preset} гривень`}
-          className={clsx("pill", value === preset && "ring-2 ring-purple-400")}
+          className={clsx(
+            "pill-amount",
+            value === preset && "ring-2 ring-purple-400",
+          )}
           onClick={() => onChange(preset)}
         >
           {preset}


### PR DESCRIPTION
## Summary
- unify donation amount preset layout using grid
- ensure preset buttons have equal width via new `pill-amount` class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc21b91848326bdaa888eb3099fcf