### PR TITLE
tweak preset grid spacing

### DIFF
--- a/components/amount-presets.tsx
+++ b/components/amount-presets.tsx
@@ -4,7 +4,7 @@ import { clsx } from "clsx";
 
 export function AmountPresets({ value, onChange }: AmountPresetsProps) {
   return (
-    <div className="grid grid-cols-4 gap-3">
+    <div className="grid grid-cols-4 gap-x-1 gap-y-3">
       {presets.map((preset) => (
         <button
           key={preset}


### PR DESCRIPTION
## Summary
- minimize horizontal distance between preset amount buttons while keeping vertical spacing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ccacc8c808326b366424b410e11fa