### PR TITLE
fix streamer page params warning

### DIFF
--- a/app/[twitchName]/page.tsx
+++ b/app/[twitchName]/page.tsx
@@ -9,7 +9,7 @@ interface StreamerPageProps {
 }
 
 export default async function StreamerPage({ params }: StreamerPageProps) {
-  const { twitchName } = params;
+  const { twitchName } = await params;
   const name = twitchName.toLowerCase();
   const streamer = await prisma.user.findFirst({
     where: { name, accounts: { some: { provider: "twitch" } } },


### PR DESCRIPTION
## Summary
- await dynamic route params in StreamerPage to satisfy Next.js expectations

## Testing
- `npm test`
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689ce8526894832680ad0f9eb6ed75e9