### PR TITLE
feat: allow dev origins in next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,1 +1,9 @@
-export default { reactStrictMode: true };
+export const allowedDevOrigins = [
+  'https://your-ngrok-url.ngrok.app',
+  'http://localhost:3000',
+];
+
+export default {
+  reactStrictMode: true,
+};
+


### PR DESCRIPTION
## Summary
- add allowedDevOrigins array to next.js config

## Testing
- `npm test`
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689ce86abd9c83269be7ecc28b46fae0