### PR TITLE
chore: ignore system directories in dev watch

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,1 +1,18 @@
-export default { reactStrictMode: true };
+function webpackDevMiddleware(config) {
+  config.watchOptions = {
+    ...config.watchOptions,
+    ignored: [
+      '**/node_modules/**',
+      '**/$RECYCLE.BIN/**',
+      '**/System Volume Information/**'
+    ]
+  };
+}
+
+export default {
+  reactStrictMode: true,
+  webpack: (config, { dev }) => {
+    if (dev) webpackDevMiddleware(config);
+    return config;
+  }
+};


### PR DESCRIPTION
## Summary
- ignore node_modules and Windows system files during dev file watching to prevent Watchpack warnings

## Testing
- `npm test`
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689ce8606be08326b84ad6bfc4e9d105