### PR TITLE
Track streamer in donation intents

### DIFF
--- a/app/api/donations/create/route.ts
+++ b/app/api/donations/create/route.ts
@@ -87,6 +87,7 @@ export async function GET(req: Request) {
     // stored with the original message (not including the identifier) and
     // the amount as provided.
     await appendIntent({
+      streamerId: slug,
       identifier,
       nickname,
       message: safeMessage,

--- a/app/api/donations/redirect/route.ts
+++ b/app/api/donations/redirect/route.ts
@@ -36,6 +36,7 @@ export async function GET(req: NextRequest) {
   const amount = clamp(rounded, 10, 29999); // UAH
   const identifier = generateIdentifier();
   await appendIntent({
+    streamerId: process.env.MONOBANK_USER_ID as string,
     identifier,
     nickname,
     message,

--- a/app/api/monobank/webhook/route.ts
+++ b/app/api/monobank/webhook/route.ts
@@ -88,7 +88,11 @@ export async function POST(req: NextRequest) {
     });
 
   const id = m[1];
-  const intent = await findIntentByIdentifier(id);
+  const streamerId =
+    req.nextUrl.searchParams.get("streamerId") ||
+    (process.env.MONOBANK_USER_ID as string) ||
+    "";
+  const intent = await findIntentByIdentifier(id, streamerId);
   if (!intent)
     return NextResponse.json({
       ok: true,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -9,7 +9,9 @@ interface SettingMap {}
 
 type SettingKey = keyof SettingMap;
 
-export async function appendIntent(intent: DonationIntent): Promise<void> {
+export async function appendIntent(
+  intent: Omit<DonationIntent, "id">,
+): Promise<void> {
   await prisma.donationIntent.create({
     data: {
       ...intent,
@@ -21,9 +23,10 @@ export async function appendIntent(intent: DonationIntent): Promise<void> {
 
 export async function findIntentByIdentifier(
   id: string,
+  streamerId: string,
 ): Promise<DonationIntent | undefined> {
-  const intent = await prisma.donationIntent.findUnique({
-    where: { identifier: id.toLowerCase() },
+  const intent = await prisma.donationIntent.findFirst({
+    where: { identifier: id.toLowerCase(), streamerId },
   });
   return intent ?? undefined;
 }

--- a/prisma/migrations/20250817081131_add_webhook_per_streamer/migration.sql
+++ b/prisma/migrations/20250817081131_add_webhook_per_streamer/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - Added the required column `streamerId` to the `DonationIntent` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_DonationIntent" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "identifier" TEXT NOT NULL,
+    "nickname" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "streamerId" TEXT NOT NULL,
+    CONSTRAINT "DonationIntent_streamerId_fkey" FOREIGN KEY ("streamerId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_DonationIntent" ("amount", "createdAt", "id", "identifier", "message", "nickname") SELECT "amount", "createdAt", "id", "identifier", "message", "nickname" FROM "DonationIntent";
+DROP TABLE "DonationIntent";
+ALTER TABLE "new_DonationIntent" RENAME TO "DonationIntent";
+CREATE UNIQUE INDEX "DonationIntent_identifier_key" ON "DonationIntent"("identifier");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,8 @@ model DonationIntent {
   message    String
   amount     Int
   createdAt  DateTime @default(now())
+  streamerId String
+  streamer   User     @relation(fields: [streamerId], references: [id], onDelete: Cascade)
   events     DonationEvent[] @relation("IntentEvents")
 }
 
@@ -46,6 +48,7 @@ model User {
   accounts      Account[]
   sessions      Session[]
   monobankSettings MonobankSettings?
+  donationIntents DonationIntent[]
 }
 
 model Account {

--- a/test/monobank-status.test.ts
+++ b/test/monobank-status.test.ts
@@ -14,6 +14,11 @@ async function setup(events: DonationEvent[]) {
     stdio: "ignore",
   });
   const { prisma } = await import("../lib/db.ts");
+  await prisma.user.upsert({
+    where: { id: "streamer" },
+    update: {},
+    create: { id: "streamer" },
+  });
   if (events.length) {
     await prisma.donationIntent.createMany({
       data: events.map((e) => ({
@@ -22,6 +27,7 @@ async function setup(events: DonationEvent[]) {
         message: e.message,
         amount: e.amount,
         createdAt: new Date(e.createdAt),
+        streamerId: "streamer",
       })),
     });
     await prisma.donationEvent.createMany({


### PR DESCRIPTION
## Summary
- link donation intents to users via `streamerId`
- lookup donation intents by streamer
- pass streamer slug when creating intents

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a18dc719a88326981c8943a98b1113