### PR TITLE
fix: resolve streamer when referer missing

### DIFF
--- a/app/api/donations/create/route.ts
+++ b/app/api/donations/create/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
 import { getMonobankSettings, appendIntent } from "@/lib/store";
-import {
-  buildMonoUrl,
-  generateIdentifier,
-  sanitizeMessage,
-} from "@/lib/utils";
+import { buildMonoUrl, generateIdentifier, sanitizeMessage } from "@/lib/utils";
 
 // API endpoint to create a Monobank donation URL.
 // It accepts query parameters for nickname, amount, message and optional
@@ -62,7 +58,9 @@ export async function GET(req: Request) {
     } catch {
       slug = "";
     }
+    if (!slug) slug = (url.searchParams.get("streamer") || "").trim();
     if (!slug) {
+      console.error("Missing streamer for donation", { referer, url: req.url });
       return NextResponse.json(
         { error: "Не вдалося визначити одержувача донату" },
         { status: 400 },


### PR DESCRIPTION
## Summary
- fallback to `streamer` query param when referer header lacks slug
- log an error before returning 400 when streamer cannot be determined

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19b62b7c88326b494e56ba42e4541