### PR TITLE
feat: track streamer on donation events

### DIFF
--- a/app/api/monobank/webhook/[webhookId]/route.ts
+++ b/app/api/monobank/webhook/[webhookId]/route.ts
@@ -118,6 +118,7 @@ export async function POST(
     message: intent.message,
     amount,
     monoComment: comment,
+    streamerId,
     createdAt: new Date().toISOString(),
   };
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -41,7 +41,9 @@ export async function findIntentByIdentifier(
   return intent ?? undefined;
 }
 
-export async function appendDonationEvent(event: DonationEvent): Promise<void> {
+export async function appendDonationEvent(
+  event: Omit<DonationEvent, "id">,
+): Promise<void> {
   await prisma.donationEvent.create({
     data: {
       ...event,

--- a/prisma/migrations/20250817081131_add_webhook_per_streamer/migration.sql
+++ b/prisma/migrations/20250817081131_add_webhook_per_streamer/migration.sql
@@ -2,6 +2,7 @@
   Warnings:
 
   - Added the required column `streamerId` to the `DonationIntent` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `streamerId` to the `DonationEvent` table without a default value. This is not possible if the table is not empty.
 
 */
 -- RedefineTables
@@ -21,5 +22,22 @@ INSERT INTO "new_DonationIntent" ("amount", "createdAt", "id", "identifier", "me
 DROP TABLE "DonationIntent";
 ALTER TABLE "new_DonationIntent" RENAME TO "DonationIntent";
 CREATE UNIQUE INDEX "DonationIntent_identifier_key" ON "DonationIntent"("identifier");
+CREATE TABLE "new_DonationEvent" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "identifier" TEXT NOT NULL,
+    "nickname" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "monoComment" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "streamerId" TEXT NOT NULL,
+    CONSTRAINT "DonationEvent_streamerId_fkey" FOREIGN KEY ("streamerId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "DonationEvent_identifier_fkey" FOREIGN KEY ("identifier") REFERENCES "DonationIntent" ("identifier") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_DonationEvent" ("amount", "createdAt", "id", "identifier", "message", "monoComment", "nickname") SELECT "amount", "createdAt", "id", "identifier", "message", "monoComment", "nickname" FROM "DonationEvent";
+DROP TABLE "DonationEvent";
+ALTER TABLE "new_DonationEvent" RENAME TO "DonationEvent";
+CREATE INDEX "DonationEvent_identifier_idx" ON "DonationEvent"("identifier");
+CREATE UNIQUE INDEX "DonationEvent_identifier_createdAt_key" ON "DonationEvent"("identifier", "createdAt");
 PRAGMA foreign_keys=ON;
 PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,8 @@ model DonationEvent {
   monoComment String
   createdAt   DateTime        @default(now())
   intent      DonationIntent? @relation("IntentEvents", fields: [identifier], references: [identifier])
+  streamerId  String
+  streamer    User            @relation(fields: [streamerId], references: [id], onDelete: Cascade)
 
   @@unique([identifier, createdAt])
   @@index([identifier])
@@ -49,6 +51,7 @@ model User {
   sessions         Session[]
   monobankSettings MonobankSettings?
   donationIntents  DonationIntent[]
+  donationEvents   DonationEvent[]
 }
 
 model Account {

--- a/test/monobank-status.test.ts
+++ b/test/monobank-status.test.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import { execSync } from "node:child_process";
 import type { DonationEvent } from "@prisma/client";
 
-async function setup(events: DonationEvent[]) {
+async function setup(events: Array<Omit<DonationEvent, "id">>) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "status-test-"));
   process.env.DATABASE_URL = `file:${path.join(dir, "test.db")}`;
   delete (globalThis as any).prisma;
@@ -51,7 +51,7 @@ test("reports inactive when no events", async () => {
 });
 
 test("returns latest event", async () => {
-  const events: DonationEvent[] = [
+  const events: Array<Omit<DonationEvent, "id">> = [
     {
       identifier: "AAA-111",
       nickname: "x",
@@ -59,6 +59,7 @@ test("returns latest event", async () => {
       amount: 1,
       monoComment: "",
       createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      streamerId: "streamer",
     },
     {
       identifier: "BBB-222",
@@ -67,6 +68,7 @@ test("returns latest event", async () => {
       amount: 2,
       monoComment: "",
       createdAt: new Date("2024-01-02T00:00:00.000Z"),
+      streamerId: "streamer",
     },
   ];
   const { GET } = await setup(events);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -43,6 +43,7 @@ function buildEvent(i: number) {
     amount: i,
     monoComment: "",
     createdAt: now,
+    streamerId: "streamer",
   };
 }
 


### PR DESCRIPTION
## Summary
- track streamer for each donation event
- persist streamer relation to user
- populate streamerId when handling Monobank webhook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a6fc96208326a558e292913d14ae