### PR TITLE
Validate streamer slug and use userId

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -9,11 +9,11 @@ interface SettingMap {}
 
 type SettingKey = keyof SettingMap;
 
-export async function findStreamerIdBySlug(
+export async function findUserIdBySlug(
   slug: string,
 ): Promise<string | undefined> {
-  const user = await prisma.user.findUnique({
-    where: { name: slug.toLowerCase() },
+  const user = await prisma.user.findFirst({
+    where: { name: slug.toLowerCase(), role: "streamer" },
     select: { id: true },
   });
   return user?.id;


### PR DESCRIPTION
## Summary
- verify streamer slug maps to a User and fetch userId
- return 400 when slug is invalid
- use userId for Monobank settings and donation intents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a86c757c832693bf2d630d32b6a4