### PR TITLE
Return null session for unauthenticated users

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -78,8 +78,9 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
     async session({ session, token }: { session: Session; token: JWT }) {
+      if (!token.id) return null;
       if (session.user) {
-        if (token.id) session.user.id = token.id as string;
+        session.user.id = token.id as string;
         if (token.role) session.user.role = token.role as string;
       }
       return session;
@@ -87,6 +88,6 @@ export const authOptions: NextAuthOptions = {
   },
 };
 
-export function getAuthSession() {
+export async function getAuthSession() {
   return getServerSession(authOptions);
 }


### PR DESCRIPTION
## Summary
- ensure session callback returns null when token lacks id
- expose async getAuthSession helper

## Testing
- `npm test` *(fails: /workspace/kitsune-donations/test/monobank-status.test.ts: test failed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1abb2b20c83268eb98555545ec588