### PR TITLE
Scope monobank status to authenticated user

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -53,8 +53,9 @@ export async function appendDonationEvent(
   });
 }
 
-export async function listDonationEvents(): Promise<DonationEvent[]> {
-  return prisma.donationEvent.findMany({ orderBy: { createdAt: "asc" } });
+export async function listDonationEvents(streamerId: string): Promise<DonationEvent[]> {
+  if (!streamerId) return [];
+  return prisma.donationEvent.findMany({ where: { streamerId }, orderBy: { createdAt: "asc" } });
 }
 
 export async function getSetting<K extends SettingKey>(

--- a/test/monobank-status.test.ts
+++ b/test/monobank-status.test.ts
@@ -44,7 +44,7 @@ async function setup(events: Array<Omit<DonationEvent, "id">>) {
 
 test("reports inactive when no events", async () => {
   const { GET } = await setup([]);
-  const res = await GET(new Request("http://localhost"));
+  const res = await GET(new Request("http://localhost", { headers: { "x-user-id": "streamer" } }));
   assert.strictEqual(res.status, 200);
   const body = await res.json();
   assert.deepStrictEqual(body, { isActive: false, event: null });
@@ -72,7 +72,7 @@ test("returns latest event", async () => {
     },
   ];
   const { GET } = await setup(events);
-  const res = await GET(new Request("http://localhost"));
+  const res = await GET(new Request("http://localhost", { headers: { "x-user-id": "streamer" } }));
   assert.strictEqual(res.status, 200);
   const body = await res.json();
   assert.strictEqual(body.isActive, true);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -61,7 +61,7 @@ test("appendDonationEvent handles concurrent writes", async () => {
   const events = Array.from({ length: 20 }, (_, i) => buildEvent(i + 100));
   await Promise.all(events.map((_, i) => appendIntent(buildIntent(i + 100))));
   await Promise.all(events.map(appendDonationEvent));
-  const saved = await listDonationEvents();
+  const saved = await listDonationEvents("streamer");
   assert.strictEqual(saved.length, events.length);
 });
 


### PR DESCRIPTION
## Summary
- authenticate monobank status requests via current session
- fetch and configure Monobank webhook per user and return user-specific donation events
- filter stored donation events by streamer ID

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1c0a1e2f48326a4efbcde42207f4b